### PR TITLE
Fix for inappropriate keywords serialization

### DIFF
--- a/rfhub2/cli/rfhub_importer.py
+++ b/rfhub2/cli/rfhub_importer.py
@@ -175,9 +175,9 @@ class RfhubImporter(object):
         for keyword in keywords:
             keyword.pop("tags")
             if keyword["args"]:
-                keyword["args"] = str([str(item) for item in keyword["args"]]).replace(
-                    "'", '"'
-                )
+                keyword["args"] = str(
+                    [str(item).replace("'", "") for item in keyword["args"]]
+                ).replace("'", '"')
             else:
                 keyword["args"] = ""
         return keywords

--- a/tests/acceptance/fixtures/test_robot.robot
+++ b/tests/acceptance/fixtures/test_robot.robot
@@ -12,3 +12,7 @@ Keyword 2 Imported From Robot File
     ...    with .robot extension
     [Arguments]    ${arg_1}    ${arg_2}
     Log    This keyword was imported from file with .resource extension, available since RFWK 3.1
+
+Keyword With Args With Comma
+    [Documentation]    Keyword With Args With Comma
+    [Arguments]    ${ok_argument}    ${not_ok_argument}=Kill.${app.replace('-', '_')}


### PR DESCRIPTION
Fix for #38 it's not perfect, because replace is missing '' around arguments,, but it at least prevents serialization issue.