### PR TITLE
Fixing _is_resource_file method to not break on exotic encoding

### DIFF
--- a/rfhub2/cli/rfhub_importer.py
+++ b/rfhub2/cli/rfhub_importer.py
@@ -240,7 +240,7 @@ class RfhubImporter(object):
         # not robot files
 
         if file.name not in INIT_FILES and file.suffix in RESOURCE_PATTERNS:
-            with open(file, "r") as f:
+            with open(file, "r", encoding="utf-8", errors="ignore") as f:
                 data = f.read()
                 return not RfhubImporter._has_test_case_table(
                     data

--- a/rfhub2/version.py
+++ b/rfhub2/version.py
@@ -1,1 +1,1 @@
-version = "0.7"
+version = "0.8"

--- a/tests/fixtures/test_file_with_tests.robot
+++ b/tests/fixtures/test_file_with_tests.robot
@@ -6,3 +6,7 @@ Test 1
 Keyword 1 Not Imported From Robot File
     [Documentation]   This keyword should not be imported from file with .robot extension
     Log    This keyword was not imported from file with .robot
+
+Keyword With Exotic Characters
+    [Documentation]    I'm keyword with exotic characters "𝕂", "𐀀", "😓", "🂲"
+    Log    I'm keyword with exotic characters "𝕂", "𐀀", "😓", "🂲"


### PR DESCRIPTION
Fix for #62 