### PR TITLE
Fix cli tests

### DIFF
--- a/tests/acceptance/resources/keywords.resource
+++ b/tests/acceptance/resources/keywords.resource
@@ -60,10 +60,10 @@ Output Should Contain
     ...    Fail if the output from the previous command doesn't contain the given string
     ...    This keyword assumes the output of the command is in
     ...    a test suite variable named \${output}
-    ...    Note: the help will be automatically wrapped, so
-    ...    you can only search for relatively short strings.
+    ${ns}    Create Dictionary    output=${output}
+    ${clean_output}    Evaluate    "".join(l.strip() for l in output.splitlines())    namespace=${ns}
     FOR    ${pattern}    IN    @{patterns}
-        Run keyword if    '''${pattern}''' not in '''${output}'''
+        Run keyword if    '''${pattern}''' not in '''${clean_output}'''
         ...    Fail    Output did not contain '${pattern}'
     END
 

--- a/tests/acceptance/resources/keywords.resource
+++ b/tests/acceptance/resources/keywords.resource
@@ -61,7 +61,7 @@ Output Should Contain
     ...    This keyword assumes the output of the command is in
     ...    a test suite variable named \${output}
     ${ns}    Create Dictionary    output=${output}
-    ${clean_output}    Evaluate    "".join(l.strip() for l in output.splitlines())    namespace=${ns}
+    ${clean_output}    Evaluate    " ".join(l.strip() for l in output.splitlines())    namespace=${ns}
     FOR    ${pattern}    IN    @{patterns}
         Run keyword if    '''${pattern}''' not in '''${clean_output}'''
         ...    Fail    Output did not contain '${pattern}'


### PR DESCRIPTION
Changes in Click 7.1 broke robot CLI tests that relied on specific line wrapping of help message. Added stripping help output of new lines/ indents to make it more robust