### PR TITLE
Modifying statistics_importert to send stats in batch per file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache: pip
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt
 before_script:
-  - wget "https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_linux64.zip"
+  - wget "https://chromedriver.storage.googleapis.com/80.0.3987.106/chromedriver_linux64.zip"
   - unzip chromedriver_linux64.zip
   - sudo mv chromedriver /usr/local/bin
   - "export DISPLAY=:99.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ uvicorn==0.11.1
 uvloop==0.14.0
 websockets==8.1
 requests==2.22.0
+progress==1.4

--- a/rfhub2/cli/cli.py
+++ b/rfhub2/cli/cli.py
@@ -73,9 +73,13 @@ def main(
         rfhub_importer = KeywordsImporter(
             client, paths, no_installed_keywords, load_mode
         )
+        loaded_collections, loaded_keywords = rfhub_importer.import_data()
+        print(
+            f"\nSuccessfully loaded {loaded_collections} collections with {loaded_keywords} keywords."
+        )
     elif mode == "statistics":
         rfhub_importer = StatisticsImporter(client, paths)
-    loaded_collections, loaded_keywords = rfhub_importer.import_data()
-    print(
-        f"\nSuccessfully loaded {loaded_collections} collections with {loaded_keywords} keywords."
-    )
+        loaded_files, loaded_statistics = rfhub_importer.import_data()
+        print(
+            f"\nSuccessfully loaded {loaded_files} files with {loaded_statistics} statistics."
+        )

--- a/rfhub2/cli/statistics_importer.py
+++ b/rfhub2/cli/statistics_importer.py
@@ -4,7 +4,7 @@ from typing import List, Set, Tuple
 
 from .api_client import Client
 from .statistics_extractor import StatisticsExtractor
-from rfhub2.model import KeywordStatisticsList
+from rfhub2.model import KeywordStatistics, KeywordStatisticsList
 
 
 class StatisticsImporter:
@@ -46,7 +46,7 @@ class StatisticsImporter:
         }
 
     def add_statistics(
-        self, statistics: List[KeywordStatisticsList]
+        self, statistics: List[List[KeywordStatistics]]
     ) -> Tuple[int, int]:
         """
         Adds statistics from provided list to app.

--- a/rfhub2/model/__init__.py
+++ b/rfhub2/model/__init__.py
@@ -93,10 +93,6 @@ class KeywordStatisticsList(BaseModel):
     def of(items: List[KeywordStatistics]) -> "KeywordStatisticsList":
         return KeywordStatisticsList(__root__=items)
 
-    @staticmethod
-    def one(item: KeywordStatistics) -> "KeywordStatisticsList":
-        return KeywordStatisticsList(__root__=[item])
-
 
 class StatisticsDeleted(BaseModel):
     deleted: int

--- a/rfhub2/version.py
+++ b/rfhub2/version.py
@@ -1,1 +1,1 @@
-version = "0.12"
+version = "0.14"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         'robotframework>=3.0.0',
         'SQLAlchemy>=1.2.0',
         'requests>=2.10.0',
-        'uvicorn>=0.7.1'
+        'uvicorn>=0.7.1',
+        'progress>=1.4'
     ],
     extras_require={
         "postgresql": ["psycopg2-binary>=2.7.4"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         'aiofiles>=0.4.0',
         'Click>=7.0',
-        'fastapi>=0.46.0',
+        'fastapi>=0.46.0,<0.53',
         'pydantic>=1.0',
         'robotframework>=3.0.0',
         'SQLAlchemy>=1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     install_requires=[
         'aiofiles>=0.4.0',
         'Click>=7.0',
-        'fastapi>=0.30.0',
+        'fastapi>=0.46.0',
+        'pydantic>=1.0',
         'robotframework>=3.0.0',
         'SQLAlchemy>=1.2.0',
         'requests>=2.10.0',

--- a/tests/acceptance/cli_population.robot
+++ b/tests/acceptance/cli_population.robot
@@ -106,14 +106,14 @@ Running Cli In Statistics Mode Should Populate App With Execution Data
     [Documentation]    Running Cli In Statistics Mode 
     ...    Should Populate App With Execution Data
     Run Cli Package With Options    --mode=statistics ${SUBDIR_PATH}
-    Output Should Contain    Successfully loaded 1 collections with 3 keywords.
+    Output Should Contain    Successfully loaded 1 files with 3 statistics.
     
 Running Cli In Statistics Mode Should Populate App With New Execution Data
     [Documentation]    Running Cli In Statistics Mode 
     ...    Should Populate App With New Execution Data
     Run Cli Package With Options    --mode=statistics ${STATISTICS_PATH}
-    Output Should Contain    Successfully loaded 5 collections with 42 keywords.
-    Output Should Contain    Record already exists for provided execution_time: 2019-12-25 11:38:08.868000
+    Output Should Contain    Successfully loaded 1 files with 42 statistics
+    Output Should Contain    Records already exist for file from ${SUBDIR_PATH}${/}output.xml
     [Teardown]    Delete All Statistics
 
 *** Keywords ***

--- a/tests/acceptance/cli_population.robot
+++ b/tests/acceptance/cli_population.robot
@@ -113,9 +113,7 @@ Running Cli In Statistics Mode Should Populate App With New Execution Data
     ...    Should Populate App With New Execution Data
     Run Cli Package With Options    --mode=statistics ${STATISTICS_PATH}
     Output Should Contain    Successfully loaded 5 collections with 42 keywords.
-    Output Should Contain    Record already exists for provided collection: BuiltIn, keyword: Log and execution_time: 2019-12-25 11:38:08.868000
-    Output Should Contain    Record already exists for provided collection: BuiltIn, keyword: Comment and execution_time: 2019-12-25 11:38:08.868000
-    Output Should Contain    Record already exists for provided collection: BuiltIn, keyword: Should Be True and execution_time: 2019-12-25 11:38:08.868000
+    Output Should Contain    Record already exists for provided execution_time: 2019-12-25 11:38:08.868000
     [Teardown]    Delete All Statistics
 
 *** Keywords ***

--- a/tests/acceptance/e2e.robot
+++ b/tests/acceptance/e2e.robot
@@ -51,7 +51,6 @@ Left Panel Keywords Should Navigate To Library Details And Show Correct Data
     [Tags]    rfhub2-155
     Sleep    1s    #Let the page load on travis
     Open ${lib_with_init} In Left Panel
-    Sleep    1s    #Let the page load on travis
     Click ${lib_with_init_2_method_1} In Left Panel
     Library title Should Be LibWithInit
     Library version Should Be version: 6.6.6

--- a/tests/acceptance/e2e.robot
+++ b/tests/acceptance/e2e.robot
@@ -51,6 +51,7 @@ Left Panel Keywords Should Navigate To Library Details And Show Correct Data
     [Tags]    rfhub2-155
     Sleep    1s    #Let the page load on travis
     Open ${lib_with_init} In Left Panel
+    Sleep    1s    #Let the page load on travis
     Click ${lib_with_init_2_method_1} In Left Panel
     Library title Should Be LibWithInit
     Library version Should Be version: 6.6.6

--- a/tests/acceptance/resources/variables.resource
+++ b/tests/acceptance/resources/variables.resource
@@ -14,7 +14,7 @@ ${detail_view_library_prefix}      ${main_page_prefix}/div/div/div
 ${detail_view_library_title}       ${detail_view_library_prefix}/h2[1]
 ${detail_view_library_version}     ${detail_view_library_prefix}/div[1]
 ${detail_view_library_scope}       ${detail_view_library_prefix}/div[2]
-${detail_view_library_overview}    ${detail_view_library_prefix}/div[4]/p
+${detail_view_library_overview}    ${detail_view_library_prefix}/div[4]/p[1]
 ${detail_view_library_ext_docs}    ${detail_view_library_prefix}/div[4]/p[2]
 ${detail_view_library_keywords}    ${detail_view_library_prefix}/h2[2]
 ${single_class_lib_items}          ${left_panel_list}/div/div/div/div

--- a/tests/acceptance/resources/variables.resource
+++ b/tests/acceptance/resources/variables.resource
@@ -24,9 +24,9 @@ ${search_result_table}             ${main_page_prefix}/div/div/div/table/tbody/t
 ${hamburger}                       //*[@id="root"]/div/header/div/button/span[1]/svg/path
 
 #VARIABLES
-${FIXTURES_PATH}                   ${CURDIR}/../../fixtures
+${FIXTURES_PATH}                   ${CURDIR}${/}..${/}..${/}fixtures
 ${INITIAL_FIXTURES}                ${FIXTURES_PATH}/initial/
 ${BACKUP_FIXTURES}                 ${FIXTURES_PATH}/initial_bkp/
 ${UPDATED_FIXTURES}                ${FIXTURES_PATH}/updated/
-${STATISTICS_PATH}                 ${FIXTURES_PATH}/statistics
-${SUBDIR_PATH}                     ${STATISTICS_PATH}/subdir
+${STATISTICS_PATH}                 ${FIXTURES_PATH}${/}statistics
+${SUBDIR_PATH}                     ${STATISTICS_PATH}${/}subdir

--- a/tests/acceptance/resources/variables.resource
+++ b/tests/acceptance/resources/variables.resource
@@ -10,7 +10,7 @@ ${lib_with_init}                   //*[contains(text(),"LibWithInit")]
 ${lib_with_init_2_method_1}        //*[contains(text(),"Lib With Init 2 Method 1")]
 ${overview}                        //*[contains(text(),"Overview")]
 ${test_libdoc_file}                //a[contains(text(), "Test Libdoc File")]
-${detail_view_library_prefix}      ${main_page_prefix}/div/div/div/
+${detail_view_library_prefix}      ${main_page_prefix}/div/div/div
 ${detail_view_library_title}       ${detail_view_library_prefix}/h2[1]
 ${detail_view_library_version}     ${detail_view_library_prefix}/div[1]
 ${detail_view_library_scope}       ${detail_view_library_prefix}/div[2]

--- a/tests/acceptance/resources/variables.resource
+++ b/tests/acceptance/resources/variables.resource
@@ -14,7 +14,7 @@ ${detail_view_library_prefix}      ${main_page_prefix}/div/div/div
 ${detail_view_library_title}       ${detail_view_library_prefix}/h2[1]
 ${detail_view_library_version}     ${detail_view_library_prefix}/div[1]
 ${detail_view_library_scope}       ${detail_view_library_prefix}/div[2]
-${detail_view_library_overview}    ${detail_view_library_prefix}/div[4]/p[1]
+${detail_view_library_overview}    ${detail_view_library_prefix}/div[4]/p
 ${detail_view_library_ext_docs}    ${detail_view_library_prefix}/div[4]/p[2]
 ${detail_view_library_keywords}    ${detail_view_library_prefix}/h2[2]
 ${single_class_lib_items}          ${left_panel_list}/div/div/div/div

--- a/tests/unit/cli/statistics_importer.py
+++ b/tests/unit/cli/statistics_importer.py
@@ -120,7 +120,9 @@ class StatisticsImporterTests(unittest.TestCase):
 
     def test_add_statistics_should_fail_on_duplicated_entries(self):
         with RequestsMock() as mock:
-            self.mock_post_request(mock, KeywordStatisticsList.of([STATISTICS_4, STATISTICS_5]), 400)
+            self.mock_post_request(
+                mock, KeywordStatisticsList.of([STATISTICS_4, STATISTICS_5]), 400
+            )
             result = self.rfhub_importer.add_statistics(
                 [STATISTICS_4, STATISTICS_5], OUTPUT_PATH
             )

--- a/tests/unit/cli/statistics_importer.py
+++ b/tests/unit/cli/statistics_importer.py
@@ -118,6 +118,14 @@ class StatisticsImporterTests(unittest.TestCase):
             )
             self.rfhub_importer.add_statistics([STATISTICS_4], OUTPUT_PATH)
 
+    def test_add_statistics_should_fail_on_duplicated_entries(self):
+        with RequestsMock() as mock:
+            self.mock_post_request(mock, KeywordStatisticsList.of([STATISTICS_4, STATISTICS_5]), 400)
+            result = self.rfhub_importer.add_statistics(
+                [STATISTICS_4, STATISTICS_5], OUTPUT_PATH
+            )
+            self.assertEqual(result, 0)
+
     def test__is_valid_execution_file_should_return_true_on_valid_file(self):
         result = StatisticsImporter._is_valid_execution_file(VALID_OUTPUT_XML)
         self.assertTrue(

--- a/tests/unit/cli/statistics_importer.py
+++ b/tests/unit/cli/statistics_importer.py
@@ -68,16 +68,14 @@ class StatisticsImporterTests(unittest.TestCase):
 
     def test_import_data_should_import_data(self):
         with RequestsMock() as mock:
-            for stat in STATISTICS:
-                self.mock_post_request(mock, KeywordStatisticsList.one(stat))
+            self.mock_post_request(mock, KeywordStatisticsList.of(STATISTICS))
             rfhub_importer = StatisticsImporter(self.client, (SUBDIR,))
             result = rfhub_importer.import_data()
             self.assertTupleEqual(result, (1, 3), msg=f"{result}")
 
     def test_import_statistics_should_import_statistics(self):
         with RequestsMock() as mock:
-            for stat in STATISTICS:
-                self.mock_post_request(mock, KeywordStatisticsList.one(stat))
+            self.mock_post_request(mock, KeywordStatisticsList.of(STATISTICS))
             rfhub_importer = StatisticsImporter(self.client, (SUBDIR,))
             result = rfhub_importer.import_statistics()
             self.assertTupleEqual(result, (1, 3), msg=f"{result}")
@@ -106,7 +104,7 @@ class StatisticsImporterTests(unittest.TestCase):
             ):
                 self.mock_post_request(mock, KeywordStatisticsList.one(stat), rc)
             result = self.rfhub_importer.add_statistics(
-                [STATISTICS_4, STATISTICS_5, STATISTICS_5]
+                [[STATISTICS_4], [STATISTICS_5], [STATISTICS_5]]
             )
             self.assertTupleEqual(result, EXPECTED_STATISTICS_COUNT)
 
@@ -123,7 +121,7 @@ class StatisticsImporterTests(unittest.TestCase):
                         "accept": "application/json",
                     },
                 )
-                self.rfhub_importer.add_statistics([STATISTICS_4])
+                self.rfhub_importer.add_statistics([[STATISTICS_4], [STATISTICS_5]])
 
     def test__is_valid_execution_file_should_return_true_on_valid_file(self):
         result = StatisticsImporter._is_valid_execution_file(VALID_OUTPUT_XML)


### PR DESCRIPTION
This addresses #197.
I've added progress bar to indicate that app is processing requests, since it took a while on my corporate network, maybe due to some high network usage lately. Here are some benchmarks:
![image](https://user-images.githubusercontent.com/35737166/77446981-6d80f280-6def-11ea-9f13-0779b48c31bd.png)

So network lag was reduced to minimum with batch mode. During spike usage of RAM was about 1 GB, but that happened when processing 700 MB file. Normally usage is around 150 MB for 1.5 GB bunch of logs.
