### PR TITLE
Bugfix/rfhub2 214 fix missing alembic ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ script:
   - ./build_ui.sh
   - python setup.py sdist bdist_wheel
   - rm test.db  #ensure we start clean slate
-  - cd ..
   - ./scripts/install_package_in_venv.sh
   - robot -A tests/acceptance/conf/default.args tests/acceptance
   - robot -A tests/acceptance/conf/postgres.args tests/acceptance

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
   - ./build_ui.sh
   - python setup.py sdist bdist_wheel
   - rm test.db  #ensure we start clean slate
+  - cd ..
   - ./scripts/install_package_in_venv.sh
   - robot -A tests/acceptance/conf/default.args tests/acceptance
   - robot -A tests/acceptance/conf/postgres.args tests/acceptance

--- a/rfhub2/db/migrate.py
+++ b/rfhub2/db/migrate.py
@@ -3,6 +3,8 @@ from alembic.runtime.migration import MigrationContext
 from alembic import command
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.engine.reflection import Inspector
+from pathlib import Path
+from os import chdir
 
 
 def has_tables(connection: Connection) -> bool:
@@ -18,8 +20,10 @@ def has_revision(connection: Connection) -> bool:
 
 
 def migrate_db(engine: Engine) -> None:
-    alembic_cfg = Config("rfhub2/alembic.ini")
+    alembic_cfg_path = Path(__file__).resolve().parent.parent.parent / "rfhub2" / "alembic.ini"
+    alembic_cfg = Config(alembic_cfg_path)
     with engine.begin() as connection:
+        chdir(Path(__file__).resolve().parent.parent / "alembic" / "versions")
         # check if database has not been migrated yet with alembic
         if has_tables(connection) and not has_revision(connection):
             # stamp database with the initial revision id, representing pre-alembic database schema

--- a/rfhub2/db/migrate.py
+++ b/rfhub2/db/migrate.py
@@ -4,7 +4,7 @@ from alembic import command
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.engine.reflection import Inspector
 from pathlib import Path
-from os import chdir
+from os import chdir, getcwd
 
 
 def has_tables(connection: Connection) -> bool:
@@ -23,9 +23,12 @@ def migrate_db(engine: Engine) -> None:
     alembic_cfg_path = Path(__file__).resolve().parent.parent.parent / "rfhub2" / "alembic.ini"
     alembic_cfg = Config(alembic_cfg_path)
     with engine.begin() as connection:
+        cwd = getcwd()
         chdir(Path(__file__).resolve().parent.parent / "alembic" / "versions")
         # check if database has not been migrated yet with alembic
         if has_tables(connection) and not has_revision(connection):
             # stamp database with the initial revision id, representing pre-alembic database schema
             command.stamp(alembic_cfg, "c54a916ec6c8")
         command.upgrade(alembic_cfg, "head")
+        chdir(cwd)
+

--- a/rfhub2/version.py
+++ b/rfhub2/version.py
@@ -1,1 +1,1 @@
-version = "0.17"
+version = "0.18"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 filename = 'rfhub2/version.py'
 exec(open(filename).read())
@@ -47,6 +47,8 @@ setup(
     ],
     packages=[
         'rfhub2',
+        'rfhub2.alembic',
+        'rfhub2.alembic.versions',
         'rfhub2.api',
         'rfhub2.api.endpoints',
         'rfhub2.api.middleware',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 filename = 'rfhub2/version.py'
 exec(open(filename).read())


### PR DESCRIPTION
This is a version that works locally on Windows and is able to be run from any directory. In v0.16-17 it run ok from rfhub2 directory, but any other gave error about missing alembic.ini file. I have no idea what happens on Travis, but it's totally different then my local env.
@pbylicki could You check on your local environment what's happening?