### PR TITLE
Hotfix/fix building ui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ before_install:
 #  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
 #  - sudo apt remove -y yarn
+  - yarn --version
   - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb && sudo dpkg -i yarn_1.19.1_all.deb
+  - yarn --version
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt
   - pushd frontend; yarn install; popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
 #  - sudo apt-get install -y -qq yarn
-  - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb | sudo dpkg -i yarn_1.19.1_all.deb
+  - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb && sudo dpkg -i yarn_1.19.1_all.deb
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt
   - pushd frontend; yarn install; popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ cache:
   pip: true
   yarn: true
   directories:
-before_install:
-  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt
   - pushd frontend; yarn install; popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
-#  - sudo apt-get -y remove yarn && sudo apt-get purge yarn
-  - yarn --version
-#  - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb && sudo dpkg -i yarn_1.19.1_all.deb
-#  - yarn --version
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt
   - pushd frontend; yarn install; popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 #  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
-  - sudo apt remove -y yarn
+#  - sudo apt remove -y yarn
   - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb && sudo dpkg -i yarn_1.19.1_all.deb
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
+#  - sudo apt-get install -y -qq yarn
+  - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb | sudo dpkg -i yarn_1.19.1_all.deb
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt
   - pushd frontend; yarn install; popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ cache:
     - frontend/node_modules
 before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+#  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
+  - sudo apt remove -y yarn
   - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb && sudo dpkg -i yarn_1.19.1_all.deb
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
   pip: true
   yarn: true
   directories:
-    - frontend/node_modules
 before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
-#  - sudo apt-get install -y -qq yarn
   - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb && sudo dpkg -i yarn_1.19.1_all.deb
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 #  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
-#  - sudo apt remove -y yarn
+  - sudo apt-get -y remove yarn && sudo apt-get purge yarn
   - yarn --version
   - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb && sudo dpkg -i yarn_1.19.1_all.deb
   - yarn --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ cache:
     - frontend/node_modules
 before_install:
   - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-#  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
-  - sudo apt-get -y remove yarn && sudo apt-get purge yarn
+#  - sudo apt-get -y remove yarn && sudo apt-get purge yarn
   - yarn --version
-  - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb && sudo dpkg -i yarn_1.19.1_all.deb
-  - yarn --version
+#  - wget https://github.com/yarnpkg/yarn/releases/download/v1.19.1/yarn_1.19.1_all.deb && sudo dpkg -i yarn_1.19.1_all.deb
+#  - yarn --version
 install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt
   - pushd frontend; yarn install; popd

--- a/build_ui.sh
+++ b/build_ui.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 pushd frontend
-#rm -rf node_modules
-#yarn install
 yarn build
 popd
 rm -r rfhub2/static/*

--- a/build_ui.sh
+++ b/build_ui.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 pushd frontend
+yarn install
 yarn build
 popd
 rm -r rfhub2/static/*

--- a/build_ui.sh
+++ b/build_ui.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 pushd frontend
-rm -rf node_modules
-yarn install
+#rm -rf node_modules
+#yarn install
 yarn build
 popd
 rm -r rfhub2/static/*

--- a/build_ui.sh
+++ b/build_ui.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 pushd frontend
+rm -rf node_modules
 yarn install
 yarn build
 popd


### PR DESCRIPTION
Yarn version changed on travis CI, and didn't work with actual node_modules, making CI fail. I tired other solutions, like downgrading yarn on travis, but this is not as straightforward as I thought. So in the end there is a brute force approach, to install all of the packages during CI.