### PR TITLE
Changing import in mixins to support rfwk 40 libdoc change

### DIFF
--- a/rfhub2/db/model/mixins.py
+++ b/rfhub2/db/model/mixins.py
@@ -1,5 +1,9 @@
 import json
-from robot.libdocpkg.htmlwriter import DocToHtml
+
+try:
+    from robot.libdocpkg.htmlutils import DocToHtml
+except ImportError:
+    from robot.libdocpkg.htmlwriter import DocToHtml
 
 
 class DocMixin:


### PR DESCRIPTION
Changing LibDoc import so both RFWK 3.x and 4.0 is handled