### PR TITLE
[rfhub-342] Added importing installed libraries by their names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - xvfb
   - postgresql
 cache:
-  pip: true
+  pip: false
   yarn: true
   directories:
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - xvfb
   - postgresql
 cache:
-  pip: false
+  pip: true
   yarn: true
   directories:
 install:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -30,3 +30,15 @@ or PostgreSQL:
 ::
 
     docker pull pbylicki/rfhub2:postgres
+
+With helm chart
+^^^^^^^^^^^^^^^
+
+create app on kubernetes cluster
+
+::
+
+    helm upgrade --install rfhub2 helm/rfhub2 -n [NAMESPACE]
+
+
+will create all needed resources with configuration from [values.yaml](helm/rfhub2/values.yaml)

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -37,7 +37,7 @@ To populate application running on localhost:
 
 ::
 
-    rfhub2-cli ../your_repo ../your_other_repo
+    rfhub2-cli ../your_repo ../your_other_repo name_of_installed_library
 
 To populate app running on another host, with non-default credentials:
 
@@ -52,19 +52,19 @@ To populate app but to skip loading RFWK installed libraries:
 
     rfhub2-cli --no-installed-keywords ../your_repo ../your_other_repo
 
-Rfhub2-cli for keywords documentation can be run in three load-modes:
+Rfhub2-cli for keywords documentation can be run in four load-modes:
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 -  | ``insert``, default mode, that will clean up existing collections app
    | and load all collections found in provided paths
-   | ``rfhub2-cli --load-mode=insert ../your_repo ../your_other_repo``
+   | ``rfhub2-cli --load-mode=insert ../your_repo ../your_other_repo name_of_installed_library``
 -  | ``append``, which will only add collections form provided paths
-   | ``rfhub2-cli --load-mode=append ../your_repo ../your_other_repo``
+   | ``rfhub2-cli --load-mode=append ../your_repo ../your_other_repo name_of_installed_library``
 -  | ``update``, which will compare existing collections with newly found
    | ones, and update existing, remove obsolete and add new ones
-   | ``rfhub2-cli --load-mode=update ../your_repo ../your_other_repo``
+   | ``rfhub2-cli --load-mode=update ../your_repo ../your_other_repo name_of_installed_library``
 -  | ``merge``, adds new and updates only matched collections, does nothing with not matched ones.
-   | ``rfhub2-cli --load-mode=merge ../your_repo ../your_other_repo``
+   | ``rfhub2-cli --load-mode=merge ../your_repo ../your_other_repo name_of_installed_library``
 
 Populating application with keywords execution statistics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rfhub2/cli/cli.py
+++ b/rfhub2/cli/cli.py
@@ -1,6 +1,6 @@
 import click
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Union
 
 from rfhub2.cli.api_client import Client
 from rfhub2.cli.keywords.keywords_importer import KeywordsImporter
@@ -57,12 +57,12 @@ from rfhub2.cli.statistics.statistics_importer import StatisticsImporter
              - `update` - removes collections not found in paths, adds new ones and updates existing ones\n
              - `merge`  - adds new and updates only matched collections, does nothing with not matched ones.""",
 )
-@click.argument("paths", nargs=-1, type=click.Path(exists=True))
+@click.argument("paths", nargs=-1)
 def main(
     app_url: str,
     user: str,
     password: str,
-    paths: Tuple[Path, ...],
+    paths: Tuple[Union[Path, str], ...],
     load_mode: str,
     mode: str,
     no_installed_keywords: bool,

--- a/rfhub2/cli/keywords/keywords_extractor.py
+++ b/rfhub2/cli/keywords/keywords_extractor.py
@@ -34,7 +34,9 @@ class CollectionUpdateWithKeywords:
 
 
 class KeywordsExtractor:
-    def __init__(self, paths: Tuple[Union[Path, str], ...], no_installed_keywords: bool) -> None:
+    def __init__(
+        self, paths: Tuple[Union[Path, str], ...], no_installed_keywords: bool
+    ) -> None:
         self.paths = paths
         self.no_installed_keywords = no_installed_keywords
 
@@ -65,7 +67,9 @@ class KeywordsExtractor:
             try:
                 return find_spec(path).submodule_search_locations[0]
             except AttributeError as e:
-                print(f"Collection {path} was neither valid path nor valid module name.")
+                print(
+                    f"Collection {path} was neither valid path nor valid module name."
+                )
                 return None
 
     def _traverse_paths(self, path: Path) -> Set[Path]:

--- a/rfhub2/cli/keywords/keywords_importer.py
+++ b/rfhub2/cli/keywords/keywords_importer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple, Union
 
 from rfhub2.cli.api_client import Client
 from rfhub2.cli.keywords.keywords_extractor import (
@@ -19,7 +19,7 @@ class KeywordsImporter:
     def __init__(
         self,
         client: Client,
-        paths: Tuple[Path, ...],
+        paths: Tuple[Union[Path, str], ...],
         no_installed_keywords: bool,
         load_mode: str,
     ) -> None:

--- a/rfhub2/version.py
+++ b/rfhub2/version.py
@@ -1,1 +1,1 @@
-version = "0.24"
+version = "0.25"

--- a/scripts/install_package_in_venv.sh
+++ b/scripts/install_package_in_venv.sh
@@ -5,3 +5,4 @@ set -e
 /opt/python/3.6.7/bin/python -m venv atests-venv
 source atests-venv/bin/activate
 pip3 install $(find dist -type f -iname "rfhub2-*.whl")[postgresql]
+pip3 install -r ../requirements-dev.txt

--- a/scripts/install_package_in_venv.sh
+++ b/scripts/install_package_in_venv.sh
@@ -5,4 +5,4 @@ set -e
 /opt/python/3.6.7/bin/python -m venv atests-venv
 source atests-venv/bin/activate
 pip3 install $(find dist -type f -iname "rfhub2-*.whl")[postgresql]
-pip3 install -r ../requirements-dev.txt
+pip3 install `cat $(find -type f -iname requirements-dev.txt) | grep robotframework-requests`

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Click>=7.0',
         'fastapi>=0.46.0',
         'pydantic>=1.0',
-        'robotframework>=3.0.0',
+        'robotframework>=3.0.0,<=3.2.2',
         'SQLAlchemy>=1.2.0',
         'requests>=2.10.0',
         'uvicorn>=0.7.1',

--- a/tests/acceptance/cli_population.robot
+++ b/tests/acceptance/cli_population.robot
@@ -17,7 +17,7 @@ Cli Should Populate App With Keywords From Provided Paths Only
     ...    test_robot library with 4 keywords loaded.
     ...    test_res_lib_dir library with 2 keywords loaded.
     ...    Successfully loaded 8 collections with 20 keywords.
-    Api Should Have With 8 Collections And 20 Keywords
+    Api Should Have 8 Collections And 20 Keywords
 
 Cli Should Populate App With Installed Keywords
     [Documentation]    Cli Should Populate App With Installed Keywords
@@ -34,7 +34,7 @@ Cli Should Populate App With Installed Keywords
     ...    BuiltIn library with 105 keywords loaded.
     ...    Telnet library with 20 keywords loaded.
     ...    Successfully loaded 10 collections with 320 keywords.
-    Api Should Have With 10 Collections And 100 Keywords
+    Api Should Have 10 Collections And 100 Keywords
 
 Cli Should Preserve All Keywords When Paths And Append Set
     [Documentation]    Cli Should Preserve All Keywords When Paths And Append Set
@@ -43,14 +43,14 @@ Cli Should Preserve All Keywords When Paths And Append Set
     Run Cli Package With Options    --load-mode=append --no-installed-keywords
     Output Should Contain
     ...    Successfully loaded 0 collections with 0 keywords.
-    Api Should Have With 10 Collections And 100 Keywords
+    Api Should Have 10 Collections And 100 Keywords
 
 Cli Should Delete All Keywords When Paths And No Installed Keywords Set
     [Documentation]    Cli Should Delete All Keywords When Paths And No Installed Keywords Set
     Run Cli Package With Options    --no-installed-keywords
     Output Should Contain
     ...    Successfully loaded 0 collections with 0 keywords.
-    Api Should Have With 0 Collections And 0 Keywords
+    Api Should Have 0 Collections And 0 Keywords
 
 Cli Should Return Unauthorised When Wrong User Given
     [Documentation]    Cli Should Return Unauthorised When Wrong User Given
@@ -88,7 +88,7 @@ Cli Update Load Mode Should Leave Application With New Set Of Collections
     ...    'Cli Should Update Existing Collections, Delete Obsolete And Add New' 
     ...    to speed up execution
     [Tags]    rfhub2-64    update
-    Api Should Have With 7 Collections And 16 Keywords
+    Api Should Have 7 Collections And 16 Keywords
     
 Running Cli Update Load Mode Second Time Should Leave Collections Untouched
     [Documentation]    Running Cli Update Load Mode Second Time 
@@ -112,7 +112,7 @@ Cli Merge Load Mode Should Update Existing Libraries And Do Not Remove Not Provi
     ...    Backup And Switch Initial With Merged Fixtures
     Run Cli Package With Options
     ...    --load-mode=merge --no-installed-keywords ${INITIAL_FIXTURES}
-    Api Should Have With 9 Collections And 22 Keywords
+    Api Should Have 9 Collections And 22 Keywords
 
 Cli Merge Load Mode Should Update Existing Resources And Do Not Remove Not Provided Paths
     [Documentation]     Cli Merge Load Mode Should Leave Application
@@ -124,7 +124,7 @@ Cli Merge Load Mode Should Update Existing Resources And Do Not Remove Not Provi
     [Setup]    Switch Merged With Merged_2 Fixtures
     Run Cli Package With Options
     ...    --load-mode=merge --no-installed-keywords ${INITIAL_FIXTURES}
-    Api Should Have With 9 Collections And 21 Keywords
+    Api Should Have 9 Collections And 21 Keywords
 
 Running Cli Merge Load Mode Second Time Should Leave Collections Untouched
     [Documentation]    Running Cli Update Load Mode Second Time
@@ -138,6 +138,24 @@ Running Cli Merge Load Mode Second Time Should Leave Collections Untouched
     [Teardown]    Run Keywords    Restore Initial Fixtures    AND
     ...    Run Cli Package With Options
     ...    --mode=insert --no-installed-keywords
+
+Running Cli With Library Names Instead Of Paths Should Populate App
+    [Documentation]    Tests loading installed library using given name, 
+    ...    instead of full path.
+    [Tags]    rfhub2-342    installed_libs
+    Run Cli Package With Options
+    ...    --no-installed-keywords RequestsLibrary
+    Output Should Contain    Successfully loaded 1 collections with 26 keywords.
+    Api Should Have 1 Collections And 26 Keywords
+
+Running Cli With Non Existing Library Names Should Load Only Found Libraries
+    [Documentation]    Tests loading installed library using given name, 
+    ...    instead of full path.
+    [Tags]    rfhub2-342    installed_libs
+    Run Cli Package With Options
+    ...    --no-installed-keywords NonExistingLibrary
+    Output Should Contain    Successfully loaded 0 collections with 0 keywords.
+    Api Should Have 0 Collections And 0 Keywords
 
 Running Cli In Statistics Mode Should Populate App With Execution Data
     [Documentation]    Running Cli In Statistics Mode 
@@ -156,6 +174,6 @@ Running Cli In Statistics Mode Should Populate App With New Execution Data
     [Teardown]    Delete All Statistics
 
 *** Keywords ***
-Api Should Have With ${n} Collections And ${m} Keywords
+Api Should Have ${n} Collections And ${m} Keywords
     collections Endpoint Should Have ${n} Items
     keywords Endpoint Should Have ${m} Items

--- a/tests/acceptance/resources/keywords.resource
+++ b/tests/acceptance/resources/keywords.resource
@@ -53,7 +53,7 @@ Output Should Contain
     ${clean_output}    Evaluate    " ".join(l.strip() for l in output.splitlines())    namespace=${ns}
     FOR    ${pattern}    IN    @{patterns}
         Run keyword if    '''${pattern}''' not in '''${clean_output}'''
-        ...    Fail    Output did not contain '${pattern}'
+        ...    Fail    Output did not contain '${pattern}'. \n${clean_output}
     END
 
 Verify URL Is Reachable

--- a/tests/unit/cli/keywords/keywords_extractor.py
+++ b/tests/unit/cli/keywords/keywords_extractor.py
@@ -1,3 +1,4 @@
+from importlib.util import find_spec
 from robot.libdocpkg import LibraryDocumentation
 import unittest
 
@@ -23,6 +24,11 @@ class KeywordsExtractorTests(unittest.TestCase):
     def test_get_libraries_paths_should_return_set_of_paths(self):
         result = self.rfhub_extractor.get_libraries_paths()
         self.assertEqual(result, EXPECTED_GET_LIBRARIES)
+
+    def test_get_library_path_from_name_should_return_path(self):
+        requests_path = find_spec('RequestsLibrary').submodule_search_locations[0]
+        results = [self.rfhub_extractor.get_library_path_from_name(path) for path in (self.fixture_path, 'RequestsLibrary', 'Noffin')]
+        self.assertListEqual(results, [str(self.fixture_path), requests_path, None])
 
     def test_get_libraries_paths_should_return_set_of_paths_on_installed_keywords(self):
         self.rfhub_extractor = KeywordsExtractor(tuple(), False)

--- a/tests/unit/cli/keywords/keywords_extractor.py
+++ b/tests/unit/cli/keywords/keywords_extractor.py
@@ -26,8 +26,11 @@ class KeywordsExtractorTests(unittest.TestCase):
         self.assertEqual(result, EXPECTED_GET_LIBRARIES)
 
     def test_get_library_path_from_name_should_return_path(self):
-        requests_path = find_spec('RequestsLibrary').submodule_search_locations[0]
-        results = [self.rfhub_extractor.get_library_path_from_name(path) for path in (self.fixture_path, 'RequestsLibrary', 'Noffin')]
+        requests_path = find_spec("RequestsLibrary").submodule_search_locations[0]
+        results = [
+            self.rfhub_extractor.get_library_path_from_name(path)
+            for path in (self.fixture_path, "RequestsLibrary", "Noffin")
+        ]
         self.assertListEqual(results, [str(self.fixture_path), requests_path, None])
 
     def test_get_libraries_paths_should_return_set_of_paths_on_installed_keywords(self):


### PR DESCRIPTION
PR to implement #342.
I'm not sure if using name `paths` should be kept in cli.py and so on. Maybe libraries/collections would be a better suiting one?