### PR TITLE
Add support for name version doc format libdoc

### DIFF
--- a/rfhub2/cli/cli.py
+++ b/rfhub2/cli/cli.py
@@ -44,6 +44,13 @@ from rfhub2.cli.statistics.statistics_importer import StatisticsImporter
     help="Specifies name of the library you are pushing the collection",
 )
 @click.option(
+    "-d",
+    "--doc-format",
+    type=click.STRING,
+    default=None,
+    help="Specifies format of the documentation libdoc will analyse",
+)
+@click.option(
     "--no-installed-keywords",
     type=click.BOOL,
     default=False,
@@ -83,13 +90,15 @@ def main(
     no_installed_keywords: bool,
     version: str,
     name: str,
+    doc_format: str
+
 ) -> None:
     """Package to populate rfhub2 with robot framework keywords
        from libraries and resource files."""
     client = Client(app_url, user, password)
     if mode == "keywords":
         rfhub_importer = KeywordsImporter(
-            client, paths, no_installed_keywords, load_mode, name, version
+            client, paths, no_installed_keywords, load_mode, name, version, doc_format
         )
         loaded_collections, loaded_keywords = rfhub_importer.import_data()
         print(

--- a/rfhub2/cli/cli.py
+++ b/rfhub2/cli/cli.py
@@ -30,6 +30,20 @@ from rfhub2.cli.statistics.statistics_importer import StatisticsImporter
     help="Specifies rfhub2 password to authenticate on endpoints that requires that. Default value is rfhub.",
 )
 @click.option(
+    "-v",
+    "--version",
+    type=click.STRING,
+    default=None,
+    help="Specifies version of the library you are pushing the collection",
+)
+@click.option(
+    "-n",
+    "--name",
+    type=click.STRING,
+    default=None,
+    help="Specifies name of the library you are pushing the collection",
+)
+@click.option(
     "--no-installed-keywords",
     type=click.BOOL,
     default=False,
@@ -49,7 +63,8 @@ from rfhub2.cli.statistics.statistics_importer import StatisticsImporter
 @click.option(
     "--load-mode",
     "-l",
-    type=click.Choice(["insert", "append", "update", "merge"], case_sensitive=False),
+    type=click.Choice(["insert", "append", "update",
+                      "merge"], case_sensitive=False),
     default="insert",
     help="""Choice parameter specifying in what load mode package should run:\n
              - `insert` - default value, removes all existing collections from app and add ones found in paths\n
@@ -66,13 +81,15 @@ def main(
     load_mode: str,
     mode: str,
     no_installed_keywords: bool,
+    version: str,
+    name: str,
 ) -> None:
     """Package to populate rfhub2 with robot framework keywords
        from libraries and resource files."""
     client = Client(app_url, user, password)
     if mode == "keywords":
         rfhub_importer = KeywordsImporter(
-            client, paths, no_installed_keywords, load_mode
+            client, paths, no_installed_keywords, load_mode, name, version
         )
         loaded_collections, loaded_keywords = rfhub_importer.import_data()
         print(

--- a/rfhub2/cli/keywords/keywords_extractor.py
+++ b/rfhub2/cli/keywords/keywords_extractor.py
@@ -35,11 +35,12 @@ class CollectionUpdateWithKeywords:
 
 
 class KeywordsExtractor:
-    def __init__(self, paths: Tuple[Path, ...], no_installed_keywords: bool, name: str = None, version: str = None) -> None:
+    def __init__(self, paths: Tuple[Path, ...], no_installed_keywords: bool, name: str = None, version: str = None, doc_format: str = None) -> None:
         self.paths = paths
         self.no_installed_keywords = no_installed_keywords
         self.name = name
         self.version = version
+        self.doc_format = doc_format
 
     def get_libraries_paths(self) -> Set[Path]:
         """
@@ -128,7 +129,8 @@ class KeywordsExtractor:
         :param path: Path
         :return: CollectionUpdateWithKeywords object
         """
-        libdoc = LibraryDocumentation(str(path))
+        libdoc = LibraryDocumentation(
+            str(path), self.name, self.version, self.doc_format)
         return CollectionUpdateWithKeywords(
             self._serialise_libdoc(libdoc, str(
                 path)), self._serialise_keywords(libdoc)
@@ -142,9 +144,9 @@ class KeywordsExtractor:
         :return: CollectionUpdate object
         """
         return CollectionUpdate(
-            name=self.name or libdoc.name,
+            name=libdoc.name,
             type=libdoc.type,
-            version=self.version or libdoc.version,
+            version=libdoc.version,
             scope=libdoc.scope,
             # named_args=libdoc.named_args, # we have not used this one, yet
             path=path,

--- a/rfhub2/cli/keywords/keywords_importer.py
+++ b/rfhub2/cli/keywords/keywords_importer.py
@@ -22,11 +22,15 @@ class KeywordsImporter:
         paths: Tuple[Union[Path, str], ...],
         no_installed_keywords: bool,
         load_mode: str,
+        name: str = None,
+        version: str = None
     ) -> None:
         self.client = client
         self.paths = paths
         self.no_installed_keywords = no_installed_keywords
         self.load_mode = load_mode
+        self.name = name
+        self.version = version
 
     def delete_all_collections(self) -> Set[int]:
         """
@@ -64,7 +68,8 @@ class KeywordsImporter:
         Import libraries to application from paths specified when invoking client.
         :return: Number of libraries and keywords loaded
         """
-        keywords_extractor = KeywordsExtractor(self.paths, self.no_installed_keywords)
+        keywords_extractor = KeywordsExtractor(
+            self.paths, self.no_installed_keywords, self.name, self.version)
         libraries_paths = keywords_extractor.get_libraries_paths()
         collections = keywords_extractor.create_collections(libraries_paths)
         if self.load_mode == "append":
@@ -82,7 +87,8 @@ class KeywordsImporter:
                     existing_collections, collections, remove_not_matched=False
                 )
             else:
-                self.delete_outdated_collections(existing_collections, collections)
+                self.delete_outdated_collections(
+                    existing_collections, collections)
         return len(loaded_collections), sum(d["keywords"] for d in loaded_collections)
 
     def update_collections(

--- a/rfhub2/cli/keywords/keywords_importer.py
+++ b/rfhub2/cli/keywords/keywords_importer.py
@@ -23,7 +23,8 @@ class KeywordsImporter:
         no_installed_keywords: bool,
         load_mode: str,
         name: str = None,
-        version: str = None
+        version: str = None,
+        doc_format: str = None
     ) -> None:
         self.client = client
         self.paths = paths
@@ -31,6 +32,7 @@ class KeywordsImporter:
         self.load_mode = load_mode
         self.name = name
         self.version = version
+        self.doc_format = doc_format
 
     def delete_all_collections(self) -> Set[int]:
         """
@@ -69,7 +71,7 @@ class KeywordsImporter:
         :return: Number of libraries and keywords loaded
         """
         keywords_extractor = KeywordsExtractor(
-            self.paths, self.no_installed_keywords, self.name, self.version)
+            self.paths, self.no_installed_keywords, self.name, self.version, self.doc_format)
         libraries_paths = keywords_extractor.get_libraries_paths()
         collections = keywords_extractor.create_collections(libraries_paths)
         if self.load_mode == "append":

--- a/tests/fixtures/initial/test_libdoc_file.xml
+++ b/tests/fixtures/initial/test_libdoc_file.xml
@@ -1,15 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<keywordspec name="Test Libdoc File" type="library" format="ROBOT" generated="20190724 14:31:46">
-<version>3.2.0</version>
-<scope>global</scope>
-<namedargs>yes</namedargs>
-<doc>Documentation for library ``Test Libdoc File``.</doc>
-<kw name="Someone Shall Pass">
-<arguments>
-<arg>who</arg>
-</arguments>
-<doc></doc>
-<tags>
-</tags>
-</kw>
+<keywordspec name="Test Libdoc File" scope="GLOBAL" type="library" format="ROBOT" generated="20190724 14:31:46" specversion="3">
+    <version>3.2.0</version>
+    <namedargs>no</namedargs>
+    <doc>Documentation for library ``Test Libdoc File``.</doc>
+    <tags>
+    </tags>
+    <inits>
+    </inits>
+    <keywords>
+        <kw name="Someone Shall Pass">
+            <arguments>
+                <arg kind="POSITIONAL_OR_NAMED" required="true" repr="who">
+                    <name>who</name>
+                </arg>
+            </arguments>
+            <doc></doc>
+            <shortdoc/>
+            <tags>
+            </tags>
+        </kw>
+    </keywords>
 </keywordspec>

--- a/tests/unit/cli/keywords/keywords_extractor.py
+++ b/tests/unit/cli/keywords/keywords_extractor.py
@@ -12,7 +12,8 @@ class KeywordsExtractorTests(unittest.TestCase):
         self.rfhub_extractor = KeywordsExtractor((self.fixture_path,), True)
 
     def test_traverse_paths_should_return_set_of_path_on_lib_with_init(self):
-        result = self.rfhub_extractor._traverse_paths(self.fixture_path / "LibWithInit")
+        result = self.rfhub_extractor._traverse_paths(
+            self.fixture_path / "LibWithInit")
         self.assertEqual(result, EXPECTED_TRAVERSE_PATHS_INIT)
 
     def test_traverse_paths_should_return_set_of_paths_on_libs_with_empty_init(self):
@@ -59,7 +60,8 @@ class KeywordsExtractorTests(unittest.TestCase):
             }
         )
         self.assertCountEqual(
-            result, [EXPECTED_COLLECTION_WITH_KW_1, EXPECTED_COLLECTION_WITH_KW_2]
+            result, [EXPECTED_COLLECTION_WITH_KW_1,
+                     EXPECTED_COLLECTION_WITH_KW_2]
         )
 
     def test_create_collection_should_return_collection(self):
@@ -97,22 +99,26 @@ class KeywordsExtractorTests(unittest.TestCase):
     def test_is_robot_keyword_file_should_return_true_on_library(self):
         file = self.fixture_path / "SingleClassLib" / "SingleClassLib.py"
         result = self.rfhub_extractor._is_robot_keyword_file(file)
-        self.assertTrue(result, "method should return true if file is python library")
+        self.assertTrue(
+            result, "method should return true if file is python library")
 
     def test_is_robot_keyword_file_should_return_true_on_libdoc(self):
         file = self.fixture_path / "test_libdoc_file.xml"
         result = self.rfhub_extractor._is_robot_keyword_file(file)
-        self.assertTrue(result, "method should return true if file is libdoc file")
+        self.assertTrue(
+            result, "method should return true if file is libdoc file")
 
     def test_is_robot_keyword_file_should_return_true_on_resource(self):
         file = self.fixture_path / "test_resource.resource"
         result = self.rfhub_extractor._is_robot_keyword_file(file)
-        self.assertTrue(result, "method should return true if file is robot resource")
+        self.assertTrue(
+            result, "method should return true if file is robot resource")
 
     def test_is_library_file_should_return_false_on_lib_with_init(self):
         file = self.fixture_path / "LibWithInit" / "__init__.py"
         result = KeywordsExtractor._is_library_file(file)
-        self.assertFalse(result, "method should return true if file is python library")
+        self.assertFalse(
+            result, "method should return true if file is python library")
 
     def test_is_library_file_should_return_false_on_library_with_init(self):
         file = self.fixture_path / "LibWithInit" / "__init__.py"
@@ -124,7 +130,8 @@ class KeywordsExtractorTests(unittest.TestCase):
     def test_is_libdoc_file_should_return_true_on_libdoc(self):
         file = self.fixture_path / "test_libdoc_file.xml"
         result = KeywordsExtractor._is_libdoc_file(file)
-        self.assertTrue(result, "method should return true if file is libdoc file")
+        self.assertTrue(
+            result, "method should return true if file is libdoc file")
 
     def test_is_libdoc_file_should_return_false_on_non_libdoc(self):
         file = self.fixture_path / "not_libdoc_file.xml"
@@ -150,7 +157,8 @@ class KeywordsExtractorTests(unittest.TestCase):
     def test_should_ignore_should_return_true_on_private(self):
         file = self.fixture_path / "_private_library.py"
         result = KeywordsExtractor._should_ignore(file)
-        self.assertTrue(result, 'method should return true if file starts with "_"')
+        self.assertTrue(
+            result, 'method should return true if file starts with "_"')
 
     def test_should_ignore_should_return_true_on_excluded(self):
         file = self.fixture_path / "remote.py"
@@ -169,7 +177,8 @@ class KeywordsExtractorTests(unittest.TestCase):
     def test_is_resource_file_should_return_true(self):
         file = self.fixture_path / "test_resource.resource"
         result = KeywordsExtractor._is_resource_file(file)
-        self.assertTrue(result, "method should return true if file is resource file")
+        self.assertTrue(
+            result, "method should return true if file is resource file")
 
     def test_is_resource_file_should_return_false(self):
         file = self.fixture_path / "test_file_with_tests.robot"
@@ -188,7 +197,8 @@ class KeywordsExtractorTests(unittest.TestCase):
     def test_has_keyword_table_should_return_true(self):
         data = "*** Keywords ***"
         result = KeywordsExtractor._has_keyword_table(data=data)
-        self.assertTrue(result, "method should return true if Keywords were found")
+        self.assertTrue(
+            result, "method should return true if Keywords were found")
 
     def test_has_keyword_table_should_return_false(self):
         data = "*** Keys ***"
@@ -200,7 +210,8 @@ class KeywordsExtractorTests(unittest.TestCase):
     def test_has_test_case_table_should_return_true(self):
         data = "*** Test Case ***"
         result = KeywordsExtractor._has_test_case_table(data=data)
-        self.assertTrue(result, "method should return true if Test Case were found")
+        self.assertTrue(
+            result, "method should return true if Test Case were found")
 
     def test_has_test_case_table_should_return_false(self):
         data = "*** Test ***"
@@ -212,25 +223,38 @@ class KeywordsExtractorTests(unittest.TestCase):
     def test_serialise_libdoc_should_return_collection(self):
         file = self.fixture_path / "test_libdoc_file.xml"
         libdoc_1 = LibraryDocumentation(file)
-        serialised_libdoc = self.rfhub_extractor._serialise_libdoc(libdoc_1, str(file))
+        serialised_libdoc = self.rfhub_extractor._serialise_libdoc(
+            libdoc_1, str(file))
         self.assertEqual(serialised_libdoc, EXPECTED_COLLECTION_2)
+
+    def test_serialise_libdoc_should_return_collection_with_override(self):
+        file = self.fixture_path / "test_resource.resource"
+        libdoc_2 = LibraryDocumentation(file)
+        rfhub_extractor = KeywordsExtractor(
+            (self.fixture_path,), True, name="Test", version="1.0.1")
+        serialised_keywords = rfhub_extractor._serialise_libdoc(
+            libdoc_2, str(file))
+        self.assertEqual(serialised_keywords, EXPECTED_COLLECTION_2_OVERRIDES)
 
     def test_serialise_keywords_should_return_keywords(self):
         file = self.fixture_path / "test_resource.resource"
         libdoc_2 = LibraryDocumentation(file)
-        serialised_keywords = self.rfhub_extractor._serialise_keywords(libdoc_2)
+        serialised_keywords = self.rfhub_extractor._serialise_keywords(
+            libdoc_2)
         self.assertEqual(serialised_keywords, EXPECTED_KEYWORDS)
 
     def test_extract_doc_from_libdoc_inits_should_return_doc_from_init(self):
         file = str(self.fixture_path / "LibWithInit")
         libdoc = LibraryDocumentation(file)
-        init_doc = self.rfhub_extractor._extract_doc_from_libdoc_inits(libdoc.inits)
+        init_doc = self.rfhub_extractor._extract_doc_from_libdoc_inits(
+            libdoc.inits)
         self.assertEqual(init_doc, EXPECTED_INIT_DOC)
 
     def test_extract_doc_from_libdoc_inits_should_return_empty_string(self):
         file = str(self.fixture_path / "SingleClassLib" / "SingleClassLib.py")
         libdoc = LibraryDocumentation(file)
-        init_doc = self.rfhub_extractor._extract_doc_from_libdoc_inits(libdoc.inits)
+        init_doc = self.rfhub_extractor._extract_doc_from_libdoc_inits(
+            libdoc.inits)
         self.assertEqual(init_doc, "")
 
     def test_robot_files_candidates_should_return_true_if_robot_files_present(self):

--- a/tests/unit/cli/keywords/test_data.py
+++ b/tests/unit/cli/keywords/test_data.py
@@ -36,6 +36,7 @@ EXPECTED_KEYWORDS = [
         tags=["first_tag", "second_tag"],
     ),
 ]
+
 EXPECTED_TRAVERSE_PATHS_INIT = {FIXTURE_PATH / "LibWithInit"}
 EXPECTED_TRAVERSE_PATHS_NO_INIT = {
     FIXTURE_PATH / "LibsWithEmptyInit" / "LibWithEmptyInit1.py",
@@ -99,7 +100,8 @@ EXISTING_COLLECTION = Collection(
         **EXPECTED_COLLECTION.dict(),
         "id": 1,
         "keywords": [
-            NestedKeyword(**{**EXPECTED_COLLECTION_KEYWORDS_1_3.dict(), "id": 1})
+            NestedKeyword(
+                **{**EXPECTED_COLLECTION_KEYWORDS_1_3.dict(), "id": 1})
         ],
     }
 )
@@ -112,6 +114,15 @@ EXPECTED_COLLECTION_2 = CollectionUpdate(
     type="LIBRARY",
     version="3.2.0",
 )
+EXPECTED_COLLECTION_2_OVERRIDES = CollectionUpdate(
+    doc="File with .resource extension with two test keywords",
+    doc_format="ROBOT",
+    name="Test",
+    path=str(FIXTURE_PATH / "test_resource.resource"),
+    scope="GLOBAL",
+    type="RESOURCE",
+    version="1.0.1",
+)
 EXPECTED_COLLECTION_KEYWORDS_2_1 = KeywordUpdate(
     args='["who"]', doc="", name="Someone Shall Pass", tags=[]
 )
@@ -121,7 +132,8 @@ EXISTING_COLLECTION_2 = Collection(
         **EXPECTED_COLLECTION_2.dict(),
         "id": 1,
         "keywords": [
-            NestedKeyword(**{**EXPECTED_COLLECTION_KEYWORDS_2_1.dict(), "id": 1})
+            NestedKeyword(
+                **{**EXPECTED_COLLECTION_KEYWORDS_2_1.dict(), "id": 1})
         ],
     }
 )


### PR DESCRIPTION
This PR add the support of the following libdoc parameters
- Name: using the --name you can override the name of the library
- version: using --version you can specify the version 
- doc-format: using the --doc-format you can specify the format of the doc.

Sorry if the code is not following the philosophy. 
I have also fixed the tests to work with Robot4.0

Regards

K