### PR TITLE
Add g++ to fix Docker Alpine builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ FROM python:3.6-alpine
 
 COPY requirements*.txt /tmp/
 
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev make && \
+RUN apk add --no-cache --virtual .build-deps g++ musl-dev make && \
     pip install --disable-pip-version-check --no-cache-dir -r /tmp/requirements.txt && \
     apk del .build-deps && \
     rm /tmp/requirements*.txt && \

--- a/docker/Dockerfile-postgres
+++ b/docker/Dockerfile-postgres
@@ -11,7 +11,7 @@ FROM python:3.6-alpine
 
 COPY requirements*.txt /tmp/
 
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev make postgresql-dev && \
+RUN apk add --no-cache --virtual .build-deps g++ musl-dev make postgresql-dev && \
     apk add --no-cache libpq &&\
     pip install --disable-pip-version-check --no-cache-dir -r /tmp/requirements.txt \
     -r /tmp/requirements-postgres.txt && \


### PR DESCRIPTION
Recent update of SQLAlchemy version to 1.4.x introduced new dependency - greenlet which requires c++ compiler to build during Alpine Docker build.