### PR TITLE
Change default load-mode to "merge"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt
   - pushd frontend; yarn install; popd
 before_script:
-  - wget "https://chromedriver.storage.googleapis.com/88.0.4324.96/chromedriver_linux64.zip"
+  - wget "https://chromedriver.storage.googleapis.com/91.0.4472.101/chromedriver_linux64.zip"
   - unzip chromedriver_linux64.zip
   - sudo mv chromedriver /usr/local/bin
   - "export DISPLAY=:99.0"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,5 @@
 ## Install dependencies
-####Python
+#### Python
 ```
 pip install -r requirements.txt -r requirements-dev.txt
 ```
@@ -73,9 +73,9 @@ To populate app but to skip loading RFWK installed libraries:
 ```
 rfhub2-cli --no-installed-keywords ../your_repo ../your_other_repo
 ```
-To preserve previously loaded collections and add new ones:
+To flush the database and to populate app with collections from provided paths:
 ```
-rfhub2-cli --no-db-flush ../your_repo ../your_other_repo
+rfhub2-cli --load-mode=insert ../your_repo ../your_other_repo
 ```
 
 ### Run unit tests

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ To populate app but to skip loading RFWK installed libraries:
 ```
 rfhub2-cli --no-installed-keywords ../your_repo ../your_other_repo
 ```
-##### Rfhub2-cli for keywords documentation can be run in three load-modes:
+##### Rfhub2-cli for keywords documentation can be run in four load-modes:
 
-- `insert`, default mode, that will clean up existing collections app and load all collections found in provided paths  
-``` rfhub2-cli --load-mode=insert ../your_repo ../your_other_repo```
-- `append`, which will only add collections form provided paths  
-``` rfhub2-cli --load-mode=append ../your_repo ../your_other_repo```
-- `update`, which will compare existing collections with newly found ones, and update existing, remove obsolete and add new ones  
-``` rfhub2-cli --load-mode=update ../your_repo ../your_other_repo```
-- `merge`, updates only matched collections, does nothing with not matched ones.
+- `merge`, default mode, updates only matched collections, does nothing with not matched ones
 ``` rfhub2-cli --load-mode=merge ../your_repo ../your_other_repo```
+- `insert`, that will clean up existing collections app and load all collections found in provided paths
+``` rfhub2-cli --load-mode=insert ../your_repo ../your_other_repo```
+- `append`, which will only add collections form provided paths
+``` rfhub2-cli --load-mode=append ../your_repo ../your_other_repo```
+- `update`, which will compare existing collections with newly found ones, and update existing, remove obsolete and add new ones
+``` rfhub2-cli --load-mode=update ../your_repo ../your_other_repo```
 
 #### Populate application with keywords execution statistics
 ##### To gather keywords execution statistics:

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -71,6 +71,11 @@ Preserving already loaded collections and adding new ones:
 
     rfhub2-cli -l append ../your_repo ../your_other_repo
 
+Flushing the database and populating app with collections from provided paths:
+::
+
+    rfhub2-cli --load-mode=insert ../your_repo ../your_other_repo
+
 Frontend
 """"""""
 To run frontend development server execute:

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -55,7 +55,9 @@ To populate app but to skip loading RFWK installed libraries:
 Rfhub2-cli for keywords documentation can be run in four load-modes:
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
--  | ``insert``, default mode, that will clean up existing collections app
+-  | ``merge``, default mode, adds new and updates only matched collections, does nothing with not matched ones
+   | ``rfhub2-cli --load-mode=merge ../your_repo ../your_other_repo name_of_installed_library``
+-  | ``insert``, that will clean up existing collections app
    | and load all collections found in provided paths
    | ``rfhub2-cli --load-mode=insert ../your_repo ../your_other_repo name_of_installed_library``
 -  | ``append``, which will only add collections form provided paths
@@ -63,8 +65,6 @@ Rfhub2-cli for keywords documentation can be run in four load-modes:
 -  | ``update``, which will compare existing collections with newly found
    | ones, and update existing, remove obsolete and add new ones
    | ``rfhub2-cli --load-mode=update ../your_repo ../your_other_repo name_of_installed_library``
--  | ``merge``, adds new and updates only matched collections, does nothing with not matched ones.
-   | ``rfhub2-cli --load-mode=merge ../your_repo ../your_other_repo name_of_installed_library``
 
 Populating application with keywords execution statistics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,11 +113,15 @@ Full list of rfhub2-cli options:
                               - `statistics` - application is working with
                               data about keywords execution.
 
-  -l, --load-mode [insert|append|update|merge]
+  -l, --load-mode [merge|insert|append|update]
                               Choice parameter specifying in what load
                               mode package should run:
 
-                              - `insert` - default value, removes all
+                              - `merge`  - default value, adds new and
+                              updates only matched collections, does
+                              nothing with not matched ones
+
+                              - `insert` - removes all
                               existing collections from app and add ones
                               found in paths
 
@@ -126,8 +130,5 @@ Full list of rfhub2-cli options:
 
                               - `update` - removes collections not found
                               in paths, adds new ones and updates existing
-                              ones.
-
-                              - `merge`, adds new and updates only matched
-                              collections, does nothing with not matched ones.
+                              ones
 

--- a/rfhub2/cli/cli.py
+++ b/rfhub2/cli/cli.py
@@ -49,13 +49,13 @@ from rfhub2.cli.statistics.statistics_importer import StatisticsImporter
 @click.option(
     "--load-mode",
     "-l",
-    type=click.Choice(["insert", "append", "update", "merge"], case_sensitive=False),
-    default="insert",
+    type=click.Choice(["merge", "insert", "append", "update"], case_sensitive=False),
+    default="merge",
     help="""Choice parameter specifying in what load mode package should run:\n
-             - `insert` - default value, removes all existing collections from app and add ones found in paths\n
+             - `merge`  - default value, adds new and updates only matched collections, does nothing with not matched ones\n
+             - `insert` - removes all existing collections from app and add ones found in paths\n
              - `append` - adds collections found in paths without removal of existing ones\n
-             - `update` - removes collections not found in paths, adds new ones and updates existing ones\n
-             - `merge`  - adds new and updates only matched collections, does nothing with not matched ones.""",
+             - `update` - removes collections not found in paths, adds new ones and updates existing ones""",
 )
 @click.argument("paths", nargs=-1)
 def main(

--- a/rfhub2/version.py
+++ b/rfhub2/version.py
@@ -1,1 +1,1 @@
-version = "0.25"
+version = "0.26"

--- a/tests/acceptance/cli_options.robot
+++ b/tests/acceptance/cli_options.robot
@@ -61,22 +61,20 @@ Documentation For Load Mode Should Be Displayed Properly
     [Documentation]    Documentation For Load Mode Should Be Displayed Properly
     [Tags]    rfhub2-64    rfhub2-330    update
     Output Should Contain
-    ...    -l, --load-mode [insert|append|update|merge]
+    ...    -l, --load-mode [merge|insert|append|update]
     ...    Choice parameter specifying in what load
     ...    mode package should run:
-    ...    - `insert` - 
-    ...    default value, removes all existing
+    ...    - `merge`  - default value, adds new and
+    ...    updates only matched collections, does
+    ...    nothing with not matched ones
+    ...    - `insert` - removes all existing
     ...    collections from app and add ones found in
     ...    paths
-    ...    - `append`
-    ...    - adds collections found 
-    ...    in paths without removal of existing ones
-    ...    - `update` - removes collections not found in
-    ...    paths, adds new ones and updates existing
-    ...    ones.
-    ...    - `merge`
-    ...    - adds new and updates only matched collections,
-    ...    does nothing with not matched ones.
+    ...    - `append` - adds collections found in paths
+    ...    without removal of existing ones
+    ...    - `update` - removes collections not found
+    ...    in paths, adds new ones and updates existing
+    ...    ones
 
 Documentation For Help Should Be Displayed Properly
     [Documentation]    Documentation For Help Should Be Displayed Properly

--- a/tests/acceptance/cli_population.robot
+++ b/tests/acceptance/cli_population.robot
@@ -21,7 +21,7 @@ Cli Should Populate App With Keywords From Provided Paths Only
 
 Cli Should Populate App With Installed Keywords
     [Documentation]    Cli Should Populate App With Installed Keywords
-    Run Cli Package
+    Run Cli Package With Options    --load-mode=insert
     Output Should Contain
     ...    Collections library with 43 keywords loaded.
     ...    XML library with 37 keywords loaded.
@@ -47,7 +47,7 @@ Cli Should Preserve All Keywords When Paths And Append Set
 
 Cli Should Delete All Keywords When Paths And No Installed Keywords Set
     [Documentation]    Cli Should Delete All Keywords When Paths And No Installed Keywords Set
-    Run Cli Package With Options    --no-installed-keywords
+    Run Cli Package With Options    --load-mode=insert --no-installed-keywords
     Output Should Contain
     ...    Successfully loaded 0 collections with 0 keywords.
     Api Should Have 0 Collections And 0 Keywords
@@ -101,7 +101,7 @@ Running Cli Update Load Mode Second Time Should Leave Collections Untouched
     Output Should Contain    Successfully loaded 0 collections with 0 keywords.
     [Teardown]    Run Keywords    Restore Initial Fixtures    AND
     ...    Run Cli Package With Options
-    ...    --mode=insert --no-installed-keywords
+    ...    --load-mode=insert --no-installed-keywords
 
 Cli Merge Load Mode Should Update Existing Libraries And Do Not Remove Not Provided Paths
     [Documentation]     Cli Merge Load Mode Should Leave Application
@@ -137,14 +137,14 @@ Running Cli Merge Load Mode Second Time Should Leave Collections Untouched
     Output Should Contain    Successfully loaded 0 collections with 0 keywords.
     [Teardown]    Run Keywords    Restore Initial Fixtures    AND
     ...    Run Cli Package With Options
-    ...    --mode=insert --no-installed-keywords
+    ...    --load-mode=insert --no-installed-keywords
 
 Running Cli With Library Names Instead Of Paths Should Populate App
     [Documentation]    Tests loading installed library using given name, 
     ...    instead of full path.
     [Tags]    rfhub2-342    installed_libs
     Run Cli Package With Options
-    ...    --no-installed-keywords RequestsLibrary
+    ...    --load-mode=insert --no-installed-keywords RequestsLibrary
     Output Should Contain    Successfully loaded 1 collections with 26 keywords.
     Api Should Have 1 Collections And 26 Keywords
 
@@ -153,7 +153,7 @@ Running Cli With Non Existing Library Names Should Load Only Found Libraries
     ...    instead of full path.
     [Tags]    rfhub2-342    installed_libs
     Run Cli Package With Options
-    ...    --no-installed-keywords NonExistingLibrary
+    ...    --load-mode=insert --no-installed-keywords NonExistingLibrary
     Output Should Contain    Successfully loaded 0 collections with 0 keywords.
     Api Should Have 0 Collections And 0 Keywords
 
@@ -161,14 +161,14 @@ Running Cli In Statistics Mode Should Populate App With Execution Data
     [Documentation]    Running Cli In Statistics Mode 
     ...    Should Populate App With Execution Data
     [Tags]    rfhub2-67    statistics
-    Run Cli Package With Options    --mode=statistics ${SUBDIR_PATH}
+    Run Cli Package With Options    --load-mode=insert --mode=statistics ${SUBDIR_PATH}
     Output Should Contain    Successfully loaded 1 files with 3 statistics.
     
 Running Cli In Statistics Mode Should Populate App With New Execution Data
     [Documentation]    Running Cli In Statistics Mode 
     ...    Should Populate App With New Execution Data
     [Tags]    rfhub2-67    statistics
-    Run Cli Package With Options    --mode=statistics ${STATISTICS_PATH}
+    Run Cli Package With Options    --load-mode=insert --mode=statistics ${STATISTICS_PATH}
     Output Should Contain    Successfully loaded 1 files with 87 statistics
     Output Should Contain    Records already exist for file from ${SUBDIR_PATH}${/}output.xml
     [Teardown]    Delete All Statistics

--- a/tests/acceptance/e2e.robot
+++ b/tests/acceptance/e2e.robot
@@ -15,7 +15,7 @@ Force Tags        e2e
 
 *** Test Cases ***
 Populated App Should Show Number Of Collections
-    Run Cli Package With Options    --no-installed-keywords ${CURDIR}/../fixtures/initial
+    Run Cli Package With Options    --load-mode=insert --no-installed-keywords ${CURDIR}/../fixtures/initial
     Collections Count On Main Page Should Be 8
 
 First Page Table Should Contain Proper Libraries Data
@@ -29,7 +29,7 @@ First Page Table Should Contain Proper Libraries Data
     SingleClassLib          LIBRARY     1.2.3       3
     Test Libdoc File        LIBRARY     3.2.0       1
     test_res_lib_dir        RESOURCE    ${EMPTY}    2
-    test_resource           RESOURCE    ${EMPTY}    2    
+    test_resource           RESOURCE    ${EMPTY}    2
     test_robot              RESOURCE    ${EMPTY}    4
 
 Left Panel Should Contain Expected Libraries
@@ -164,8 +164,8 @@ Test Setup For Collections Update
     Collections Count On Main Page Should Be 7
 
 Test Setup For Collections Statistics
-    Run Cli Package With Options    --no-installed-keywords ${STATISTICS_PATH} ${CURDIR}/resources
-    Run Cli Package With Options    -m statistics ${STATISTICS_PATH}
+    Run Cli Package With Options    --load-mode=insert --no-installed-keywords ${STATISTICS_PATH} ${CURDIR}/resources
+    Run Cli Package With Options    --load-mode=insert -m statistics ${STATISTICS_PATH}
     Navigate To Main Page
     Sleep    1s
     Collections Count On Main Page Should Be 2

--- a/tests/acceptance/resources/keywords.resource
+++ b/tests/acceptance/resources/keywords.resource
@@ -83,7 +83,7 @@ Delete All Statistics
     Should Be Equal As Integers    ${response.status_code}    204
 
 Run Cli Package Without Installed Keywords
-    Run Cli Package With Options    --no-installed-keywords ${INITIAL_FIXTURES}
+    Run Cli Package With Options    --load-mode=insert --no-installed-keywords ${INITIAL_FIXTURES}
 
 Backup And Switch Initial With Updated Fixtures
     Move Directory      ${INITIAL_FIXTURES}     ${BACKUP_FIXTURES}


### PR DESCRIPTION
Hi there!

This PR changes the default load-mode from "insert" to "merge" (fixes #401).

- CLI help section for --load-mode updated
- README.md updated
- DEVELOPMENT.md updated
- tests updated (basically added an explicit "load-mode=insert" when no option was provided)
- bumped chromedriver version for .travis.yml