### PR TITLE
Auto update chromedriver version in Travis Job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ install:
   - pip install -r requirements.txt -r requirements-dev.txt -r requirements-postgres.txt
   - pushd frontend; yarn install; popd
 before_script:
-  - wget "https://chromedriver.storage.googleapis.com/88.0.4324.96/chromedriver_linux64.zip"
+  - export CHROME_VERSION=`google-chrome-stable --version | cut -d' ' -f3 | sed 's/\.[[:digit:]]*$//'`
+  - wget --no-verbose -O /tmp/chromeversion.txt https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}
+  - export CHROME_DRIVER_VERSION=`cat /tmp/chromeversion.txt`
+  - wget --no-verbose -O chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - sudo mv chromedriver /usr/local/bin
   - "export DISPLAY=:99.0"


### PR DESCRIPTION
Since most of the CI builds are failing due to the incompatibility chrome <-> chromedriver, this PR adds a slight change to the travis job config: now, the chromedriver is installed matching the currently installed chrome version. It removes the need to manually bump the chromedriver version each time a new chrome update is released.

The script follows the procedure given here: https://chromedriver.chromium.org/downloads/version-selection.

(BTW, https://travis-ci.org will be closed down for good on June 15th so you may migrate to https://travis-ci).