### PR TITLE
Add new options to filter keywords by their tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,24 @@ To populate app but to skip loading RFWK installed libraries:
 ```
 rfhub2-cli --no-installed-keywords ../your_repo ../your_other_repo
 ```
-##### Rfhub2-cli for keywords documentation can be run in four load-modes:
+To populate app only including or excluding keywords with tags matching custom patterns (more information on the include/exclude feature [here](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#tag-patterns)):
+```bash
+# Including keywords containing tag "your-tag" and not containing tag "your-other-tag":
+rfhub2-cli --include your-tag --exclude your-other-tag ../your_repo ../your_other_repo
 
+# To populate app only with keywords containing either tag "💡" or "🔧", and tag "🤖":
+rfhub2-cli --include 💡OR🔧AND🤖 ../your_repo ../your_other_repo
+
+# To populate app only with keywords containing tags starting by "important-tag-":
+rfhub2-cli --include important-tag-* ../your_repo ../your_other_repo
+```
+
+##### Rfhub2-cli for keywords documentation can be run in three load-modes:
 - `merge`, default mode, updates only matched collections, does nothing with not matched ones
 ``` rfhub2-cli --load-mode=merge ../your_repo ../your_other_repo```
 - `insert`, that will clean up existing collections app and load all collections found in provided paths
 ``` rfhub2-cli --load-mode=insert ../your_repo ../your_other_repo```
-- `append`, which will only add collections form provided paths
+- `append`, which will only add collections from provided paths
 ``` rfhub2-cli --load-mode=append ../your_repo ../your_other_repo```
 - `update`, which will compare existing collections with newly found ones, and update existing, remove obsolete and add new ones
 ``` rfhub2-cli --load-mode=update ../your_repo ../your_other_repo```

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -146,14 +146,14 @@ Full list of rfhub2-cli options:
                               in paths, adds new ones and updates existing
                               ones
 
---include TEXT                Include all the keywords containing tags
+-i, --include TEXT            Include all the keywords containing tags
                               matching this pattern. This option has the
                               same behavior as the --include option of the
                               RobotFramework CLI (with the same format).
                               By default, all the keywords found are
                               included.
 
---exclude TEXT                Exclude all the keywords containing tags
+-e, --exclude TEXT            Exclude all the keywords containing tags
                               matching this pattern. This option has the
                               same behavior as the --exclude option of the
                               RobotFramework CLI (with the same format).

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -52,6 +52,20 @@ To populate app but to skip loading RFWK installed libraries:
 
     rfhub2-cli --no-installed-keywords ../your_repo ../your_other_repo
 
+To populate app only including or excluding keywords with tags matching custom patterns
+(more information on the include/exclude feature `here <https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#tag-patterns>`_):
+
+::
+
+    # Including keywords containing tag "your-tag" and not containing tag "your-other-tag":
+    rfhub2-cli --include your-tag --exclude your-other-tag ../your_repo ../your_other_repo
+
+    # To populate app only with keywords containing either tag "💡" or tag "🔧", and tag "🤖":
+    rfhub2-cli --include 💡OR🔧AND🤖 ../your_repo ../your_other_repo
+
+    # To populate app only with keywords containing tags starting by "important-tag-":
+    rfhub2-cli --include important-tag-* ../your_repo ../your_other_repo
+
 Rfhub2-cli for keywords documentation can be run in four load-modes:
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
@@ -60,7 +74,7 @@ Rfhub2-cli for keywords documentation can be run in four load-modes:
 -  | ``insert``, that will clean up existing collections app
    | and load all collections found in provided paths
    | ``rfhub2-cli --load-mode=insert ../your_repo ../your_other_repo name_of_installed_library``
--  | ``append``, which will only add collections form provided paths
+-  | ``append``, which will only add collections from provided paths
    | ``rfhub2-cli --load-mode=append ../your_repo ../your_other_repo name_of_installed_library``
 -  | ``update``, which will compare existing collections with newly found
    | ones, and update existing, remove obsolete and add new ones
@@ -132,3 +146,17 @@ Full list of rfhub2-cli options:
                               in paths, adds new ones and updates existing
                               ones
 
+--include TEXT                Include all the keywords containing tags
+                              matching this pattern. This option has the
+                              same behavior as the --include option of the
+                              RobotFramework CLI (with the same format).
+                              By default, all the keywords found are
+                              included.
+
+--exclude TEXT                Exclude all the keywords containing tags
+                              matching this pattern. This option has the
+                              same behavior as the --exclude option of the
+                              RobotFramework CLI (with the same format).
+                              By default, no keyword is excluded.
+
+--help                        Show this message and exit.

--- a/rfhub2/cli/cli.py
+++ b/rfhub2/cli/cli.py
@@ -57,6 +57,22 @@ from rfhub2.cli.statistics.statistics_importer import StatisticsImporter
              - `append` - adds collections found in paths without removal of existing ones\n
              - `update` - removes collections not found in paths, adds new ones and updates existing ones""",
 )
+@click.option(
+    "--include",
+    type=click.STRING,
+    default="",
+    help="Include all the keywords containing tags matching this pattern. "
+    "This option has the same behavior as the --include option of the RobotFramework CLI (with the same format). "
+    "By default, all the keywords found are included.",
+)
+@click.option(
+    "--exclude",
+    type=click.STRING,
+    default="",
+    help="Exclude all the keywords containing tags matching this pattern. "
+    "This option has the same behavior as the --exclude option of the RobotFramework CLI (with the same format). "
+    "By default, no keyword is excluded.",
+)
 @click.argument("paths", nargs=-1)
 def main(
     app_url: str,
@@ -66,13 +82,15 @@ def main(
     load_mode: str,
     mode: str,
     no_installed_keywords: bool,
+    include: str,
+    exclude: str,
 ) -> None:
     """Package to populate rfhub2 with robot framework keywords
        from libraries and resource files."""
     client = Client(app_url, user, password)
     if mode == "keywords":
         rfhub_importer = KeywordsImporter(
-            client, paths, no_installed_keywords, load_mode
+            client, paths, no_installed_keywords, load_mode, include, exclude
         )
         loaded_collections, loaded_keywords = rfhub_importer.import_data()
         print(

--- a/rfhub2/cli/cli.py
+++ b/rfhub2/cli/cli.py
@@ -59,6 +59,7 @@ from rfhub2.cli.statistics.statistics_importer import StatisticsImporter
 )
 @click.option(
     "--include",
+    "-i",
     type=click.STRING,
     default="",
     help="Include all the keywords containing tags matching this pattern. "
@@ -67,6 +68,7 @@ from rfhub2.cli.statistics.statistics_importer import StatisticsImporter
 )
 @click.option(
     "--exclude",
+    "-e",
     type=click.STRING,
     default="",
     help="Exclude all the keywords containing tags matching this pattern. "

--- a/rfhub2/cli/keywords/keywords_importer.py
+++ b/rfhub2/cli/keywords/keywords_importer.py
@@ -22,11 +22,15 @@ class KeywordsImporter:
         paths: Tuple[Union[Path, str], ...],
         no_installed_keywords: bool,
         load_mode: str,
+        include: str,
+        exclude: str,
     ) -> None:
         self.client = client
         self.paths = paths
         self.no_installed_keywords = no_installed_keywords
         self.load_mode = load_mode
+        self.include = include
+        self.exclude = exclude
 
     def delete_all_collections(self) -> Set[int]:
         """
@@ -64,7 +68,9 @@ class KeywordsImporter:
         Import libraries to application from paths specified when invoking client.
         :return: Number of libraries and keywords loaded
         """
-        keywords_extractor = KeywordsExtractor(self.paths, self.no_installed_keywords)
+        keywords_extractor = KeywordsExtractor(
+            self.paths, self.no_installed_keywords, self.include, self.exclude
+        )
         libraries_paths = keywords_extractor.get_libraries_paths()
         collections = keywords_extractor.create_collections(libraries_paths)
         if self.load_mode == "append":

--- a/rfhub2/version.py
+++ b/rfhub2/version.py
@@ -1,1 +1,1 @@
-version = "0.26"
+version = "0.27"

--- a/tests/acceptance/cli_options.robot
+++ b/tests/acceptance/cli_options.robot
@@ -76,6 +76,24 @@ Documentation For Load Mode Should Be Displayed Properly
     ...    in paths, adds new ones and updates existing
     ...    ones
 
+Documentation For Include Exclude Should Be Displayed Properly
+    [Documentation]    Documentation For Include Exclude options Should Be Displayed Properly
+    [Tags]    include-exclude
+    Output Should Contain
+    ...    --include TEXT
+    ...    Include all the keywords containing tags
+    ...    matching this pattern. This option has the
+    ...    same behavior as the --include option of the
+    ...    RobotFramework CLI (with the same format).
+    ...    By default, all the keywords found are
+    ...    included.
+    ...    --exclude TEXT
+    ...    Exclude all the keywords containing tags
+    ...    matching this pattern. This option has the
+    ...    same behavior as the --exclude option of the
+    ...    RobotFramework CLI (with the same format).
+    ...    By default, no keyword is excluded.
+
 Documentation For Help Should Be Displayed Properly
     [Documentation]    Documentation For Help Should Be Displayed Properly
     Output Should Contain

--- a/tests/acceptance/cli_options.robot
+++ b/tests/acceptance/cli_options.robot
@@ -80,14 +80,14 @@ Documentation For Include Exclude Should Be Displayed Properly
     [Documentation]    Documentation For Include Exclude options Should Be Displayed Properly
     [Tags]    include-exclude
     Output Should Contain
-    ...    --include TEXT
+    ...    -i, --include TEXT
     ...    Include all the keywords containing tags
     ...    matching this pattern. This option has the
     ...    same behavior as the --include option of the
     ...    RobotFramework CLI (with the same format).
     ...    By default, all the keywords found are
     ...    included.
-    ...    --exclude TEXT
+    ...    -e, --exclude TEXT
     ...    Exclude all the keywords containing tags
     ...    matching this pattern. This option has the
     ...    same behavior as the --exclude option of the

--- a/tests/acceptance/cli_population.robot
+++ b/tests/acceptance/cli_population.robot
@@ -157,13 +157,111 @@ Running Cli With Non Existing Library Names Should Load Only Found Libraries
     Output Should Contain    Successfully loaded 0 collections with 0 keywords.
     Api Should Have 0 Collections And 0 Keywords
 
+Running Cli Without Include Or Exclude Options Should Load All Keywords
+    [Documentation]    Test loading Keywords without including or excluding
+                ...    any tags should load all keywords
+    [Tags]    include-exclude
+    [Template]    Run Cli With Options ${options} And Expect Api To Have ${n} Collections And ${m} Keywords
+    [Setup]    Run Keywords
+    ...        Backup And Switch Initial With Include_Exclude Fixtures
+    --load-mode=insert --no-installed-keywords ${INITIAL_FIXTURES}                              3    11
+    --load-mode=insert --no-installed-keywords --include "" ${INITIAL_FIXTURES}                 3    11
+    --load-mode=insert --no-installed-keywords --exclude "" ${INITIAL_FIXTURES}                 3    11
+    --load-mode=insert --no-installed-keywords --include "" --exclude "" ${INITIAL_FIXTURES}    3    11
+    [Teardown]    Restore Initial Fixtures
+
+Running Cli And Including Tags Should Load Only Keywords Matching Include Pattern
+    [Documentation]    Test loading Keywords and including tags
+    [Tags]    include-exclude
+    [Template]    Run Cli With Options ${options} And Expect Api To Have ${n} Collections And ${m} Keywords
+    [Setup]    Run Keywords
+    ...        Backup And Switch Initial With Include_Exclude Fixtures
+    --load-mode=insert --no-installed-keywords --include 👻 ${INITIAL_FIXTURES}              3    2
+    --load-mode=insert --no-installed-keywords --include 👻AND❤️ ${INITIAL_FIXTURES}        3    1
+    --load-mode=insert --no-installed-keywords --include 👻OR❤️ ${INITIAL_FIXTURES}         3    5
+    --load-mode=insert --no-installed-keywords --include 👻OR❤️NOT🚀 ${INITIAL_FIXTURES}    3    3
+    --load-mode=insert --no-installed-keywords --include *⛅️*✈️* ${INITIAL_FIXTURES}        3    1
+    --load-mode=insert --no-installed-keywords --include s[a-z]rt_a? ${INITIAL_FIXTURES}     3    1
+    [Teardown]    Restore Initial Fixtures
+
+Running Cli And Excluding Tags Should Load Only Keywords Not Matching Exclude Pattern
+    [Documentation]    Test loading Keywords and excluding tags
+    [Tags]    include-exclude
+    [Template]    Run Cli With Options ${options} And Expect Api To Have ${n} Collections And ${m} Keywords
+    [Setup]    Run Keywords
+    ...        Backup And Switch Initial With Include_Exclude Fixtures
+    --load-mode=insert --no-installed-keywords --exclude 👻 ${INITIAL_FIXTURES}              3    9
+    --load-mode=insert --no-installed-keywords --exclude 👻AND❤️ ${INITIAL_FIXTURES}        3    10
+    --load-mode=insert --no-installed-keywords --exclude 👻OR❤️ ${INITIAL_FIXTURES}         3    6
+    --load-mode=insert --no-installed-keywords --exclude 👻OR❤️NOT🚀 ${INITIAL_FIXTURES}    3    8
+    --load-mode=insert --no-installed-keywords --exclude *⛅️*✈️* ${INITIAL_FIXTURES}        3    10
+    --load-mode=insert --no-installed-keywords --exclude *⛅️?✈️? ${INITIAL_FIXTURES}        3    11
+    --load-mode=insert --no-installed-keywords --exclude s[a-z]rt_a? ${INITIAL_FIXTURES}     3    10
+    [Teardown]    Restore Initial Fixtures
+
+Running Cli And Including + Excluding Tags Should Load Proper Keywords
+    [Documentation]    Test loading Keywords and including + excluding tags
+    [Tags]    include-exclude
+    [Template]    Run Cli With Options ${options} And Expect Api To Have ${n} Collections And ${m} Keywords
+    [Setup]    Run Keywords
+    ...        Backup And Switch Initial With Include_Exclude Fixtures
+    --load-mode=insert --no-installed-keywords --include ❤️ --exclude 👻 ${INITIAL_FIXTURES}              3    3
+    --load-mode=insert --no-installed-keywords --include ❤️OR👻 --exclude ❤️AND👻 ${INITIAL_FIXTURES}    3    4
+    [Teardown]    Restore Initial Fixtures
+
+Running Cli With Merge Load Mode And Including + Excluding Tags Should Load Proper Keywords
+    [Documentation]    Test loading Keywords and including + excluding tags
+    [Tags]    include-exclude    merge
+    [Setup]    Run Keywords
+    ...        Backup And Switch Initial With Include_Exclude Fixtures
+    Run Cli Package With Options
+    ...    --load-mode=insert --no-installed-keywords --exclude 👻 ${INITIAL_FIXTURES}
+    # 1/3 in ResourceLibrary1, 5/5 in ResourceLibrary2, 3/3 in PyLibrary
+    Api Should Have 3 Collections And 9 Keywords
+    Run Cli Package With Options
+    ...    --load-mode=merge --no-installed-keywords --include 👻 ${INITIAL_FIXTURES}
+    # 2/3 in ResourceLibrary1, 0/5 in ResourceLibrary2, 3/3 (untouched) in PyLibrary
+    Api Should Have 3 Collections And 5 Keywords
+    [Teardown]    Restore Initial Fixtures
+
+Running Cli With Append Load Mode And Including + Excluding Tags Should Load Proper Keywords
+    [Documentation]    Test loading Keywords and including + excluding tags
+    [Tags]    include-exclude    append
+    [Setup]    Run Keywords
+    ...        Backup And Switch Initial With Include_Exclude Fixtures
+    Run Cli Package With Options
+    ...    --load-mode=insert --no-installed-keywords --exclude 👻 ${INITIAL_FIXTURES}
+    # 1/3 in ResourceLibrary1, 5/5 in ResourceLibrary2, 3/3 in PyLibrary
+    Api Should Have 3 Collections And 9 Keywords
+    Run Cli Package With Options
+    ...    --load-mode=append --no-installed-keywords --include ❤️ ${INITIAL_FIXTURES}
+    # 1/3❤️ + 1/3 in ResourceLibrary1, 1/5❤️ + 5/5 in ResourceLibrary2, 3/3❤️ + 2/3 in PyLibrary
+    Api Should Have 6 Collections And 13 Keywords
+    [Teardown]    Restore Initial Fixtures
+
+Running Cli With Update Load Mode And Including + Excluding Tags Should Load Proper Keywords
+    [Documentation]    Test loading Keywords and including + excluding tags
+    [Tags]    include-exclude    update
+    [Setup]    Run Keywords
+    ...        Backup And Switch Initial With Include_Exclude Fixtures
+    Run Cli Package With Options
+    ...    --load-mode=insert --no-installed-keywords --exclude 👻 ${INITIAL_FIXTURES}
+    # 1/3 in ResourceLibrary1, 5/5 in ResourceLibrary2, 3/3 in PyLibrary
+    Api Should Have 3 Collections And 9 Keywords
+    OperatingSystem.Remove Files    ${INITIAL_FIXTURES}${/}PyLibrary${/}__init__.py
+    Run Cli Package With Options
+    ...    --load-mode=update --no-installed-keywords --include 👻OR🚂 ${INITIAL_FIXTURES}
+    # 2/3 in ResourceLibrary1, 0/5 in ResourceLibrary2, 0/3 in PyLibrary (deleted)
+    Api Should Have 2 Collections And 2 Keywords
+    [Teardown]    Restore Initial Fixtures
+
 Running Cli In Statistics Mode Should Populate App With Execution Data
     [Documentation]    Running Cli In Statistics Mode 
     ...    Should Populate App With Execution Data
     [Tags]    rfhub2-67    statistics
     Run Cli Package With Options    --load-mode=insert --mode=statistics ${SUBDIR_PATH}
     Output Should Contain    Successfully loaded 1 files with 3 statistics.
-    
+
 Running Cli In Statistics Mode Should Populate App With New Execution Data
     [Documentation]    Running Cli In Statistics Mode 
     ...    Should Populate App With New Execution Data
@@ -177,3 +275,9 @@ Running Cli In Statistics Mode Should Populate App With New Execution Data
 Api Should Have ${n} Collections And ${m} Keywords
     collections Endpoint Should Have ${n} Items
     keywords Endpoint Should Have ${m} Items
+
+Run Cli With Options ${options} And Expect Api To Have ${n} Collections And ${m} Keywords
+    [Documentation]    Run pkg from CLI and expect a certain amount of collections
+    ...    and keywords
+    Run Cli Package With Options    ${options}
+    Api Should Have ${n} Collections And ${m} Keywords

--- a/tests/acceptance/e2e.robot
+++ b/tests/acceptance/e2e.robot
@@ -141,7 +141,7 @@ App Should Display Libraries With Times Used Statistics
     [Setup]    Test Setup For Collections Statistics
     [Template]    Table Should Contain Library Data  
     e2e_keywords       RESOURCE	   ${EMPTY}    17	  114
-    keywords	       RESOURCE	   ${EMPTY}    14	  67
+    keywords	       RESOURCE	   ${EMPTY}    15	  67
 
 App Should Display Keywords Statistics For Single Libary
     [Documentation]    App Should Display Keywords Statistics For Single Libary

--- a/tests/acceptance/resources/keywords.resource
+++ b/tests/acceptance/resources/keywords.resource
@@ -93,6 +93,10 @@ Backup And Switch Initial With Merged Fixtures
     Move Directory      ${INITIAL_FIXTURES}     ${BACKUP_FIXTURES}
     Copy Directory      ${MERGED_FIXTURES}      ${INITIAL_FIXTURES}
 
+Backup And Switch Initial With Include_Exclude Fixtures
+    Move Directory      ${INITIAL_FIXTURES}     ${BACKUP_FIXTURES}
+    Copy Directory      ${INCLUDE_EXCLUDE_FIXTURES}    ${INITIAL_FIXTURES}
+
 Switch Merged With Merged_2 Fixtures
     Remove Directory    ${INITIAL_FIXTURES}     recursive=True
     Copy Directory      ${MERGED_2_FIXTURES}    ${INITIAL_FIXTURES}

--- a/tests/acceptance/resources/variables.resource
+++ b/tests/acceptance/resources/variables.resource
@@ -37,6 +37,7 @@ ${BACKUP_FIXTURES}                 ${FIXTURES_PATH}/initial_bkp/
 ${UPDATED_FIXTURES}                ${FIXTURES_PATH}/updated/
 ${MERGED_FIXTURES}                 ${FIXTURES_PATH}/merged/
 ${MERGED_2_FIXTURES}               ${FIXTURES_PATH}/merged_2/
+${INCLUDE_EXCLUDE_FIXTURES}        ${FIXTURES_PATH}/include_exclude/
 ${STATISTICS_PATH}                 ${FIXTURES_PATH}${/}statistics
 ${SUBDIR_PATH}                     ${STATISTICS_PATH}${/}subdir
 ${DB_PATH}                         ${CURDIR}/../../../test.db

--- a/tests/fixtures/include_exclude/PyLibrary/__init__.py
+++ b/tests/fixtures/include_exclude/PyLibrary/__init__.py
@@ -1,0 +1,16 @@
+from robot.api.deco import keyword
+
+
+class PyLibrary(object):
+    __version__ = "1.0.0"
+
+    @keyword(tags=["❤️", "💀"])
+    def keyword_heart_skull(self):
+        pass
+
+    @keyword(tags=["❤️", "🚂"])
+    def keyword_heart_engine(self):
+        pass
+
+    def keyword_no_tag(self):
+        pass

--- a/tests/fixtures/include_exclude/ResourceLibrary1.resource
+++ b/tests/fixtures/include_exclude/ResourceLibrary1.resource
@@ -1,0 +1,12 @@
+*** Keywords ***
+Keyword Ghost Heart Rocket
+    [Tags]    👻    ❤️    🚀
+    No Operation
+
+Keyword Rocket
+    [Tags]    🚀
+    No Operation
+
+Keyword Ghost
+    [Tags]    👻
+    No Operation

--- a/tests/fixtures/include_exclude/ResourceLibrary2.resource
+++ b/tests/fixtures/include_exclude/ResourceLibrary2.resource
@@ -1,0 +1,19 @@
+*** Keywords ***
+Keyword Rocket Moon Heart
+    [Tags]    🚀    🌑    ❤️
+    No Operation
+
+Keyword TextualTag
+    [Tags]    STR_tag
+    No Operation
+
+Keyword Rocket
+    [Tags]    🚀
+    No Operation
+
+Keyword Airplane In The Clouds
+    [Tags]    ☁️⛅️☁️✈️☁️☁️
+    No Operation
+
+Keyword No Tag
+    No Operation

--- a/tests/unit/cli/keywords/keywords_extractor.py
+++ b/tests/unit/cli/keywords/keywords_extractor.py
@@ -9,7 +9,7 @@ from .test_data import *
 class KeywordsExtractorTests(unittest.TestCase):
     def setUp(self) -> None:
         self.fixture_path = FIXTURE_PATH
-        self.rfhub_extractor = KeywordsExtractor((self.fixture_path,), True)
+        self.rfhub_extractor = KeywordsExtractor((self.fixture_path,), True, "", "")
 
     def test_traverse_paths_should_return_set_of_path_on_lib_with_init(self):
         result = self.rfhub_extractor._traverse_paths(self.fixture_path / "LibWithInit")
@@ -34,7 +34,7 @@ class KeywordsExtractorTests(unittest.TestCase):
         self.assertListEqual(results, [str(self.fixture_path), requests_path, None])
 
     def test_get_libraries_paths_should_return_set_of_paths_on_installed_keywords(self):
-        self.rfhub_extractor = KeywordsExtractor(tuple(), False)
+        self.rfhub_extractor = KeywordsExtractor(tuple(), False, "", "")
         result = self.rfhub_extractor.get_libraries_paths()
         self.assertEqual(result, EXPECTED_BUILT_IN_LIBS)
 
@@ -45,6 +45,8 @@ class KeywordsExtractorTests(unittest.TestCase):
                 self.fixture_path / "LibsWithEmptyInit",
             ),
             True,
+            "",
+            "",
         )
         result = self.rfhub_extractor.get_libraries_paths()
         self.assertEqual(
@@ -244,3 +246,121 @@ class KeywordsExtractorTests(unittest.TestCase):
                 self.fixture_path / "LibWithEmptyInit"
             )
         )
+
+    def test_filter_keywords_no_include_no_exclude_should_return_all(self):
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="", exclude=""
+        )
+        self.assertEqual(filtered_kws_list, KEYWORDDOC_WITH_TAGS)
+
+    def test_filter_keywords_only_include_should_filter_keywords(self):
+        tag1_kws = set(kw for kw in KEYWORDDOC_WITH_TAGS if "tag1" in list(kw.tags))
+        tag2_kws = set(kw for kw in KEYWORDDOC_WITH_TAGS if "tag2" in list(kw.tags))
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="tag1", exclude=""
+        )
+        self.assertCountEqual(filtered_kws_list, tag1_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="tag2", exclude=""
+        )
+        self.assertCountEqual(filtered_kws_list, tag2_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="tag1ORnot_at_tag", exclude=""
+        )
+        self.assertCountEqual(filtered_kws_list, tag1_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="tag1ORtag2", exclude=""
+        )
+        self.assertCountEqual(filtered_kws_list, tag1_kws | tag2_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="tag1ANDtag2", exclude=""
+        )
+        self.assertCountEqual(filtered_kws_list, tag1_kws & tag2_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="not_a_tag", exclude=""
+        )
+        self.assertCountEqual(filtered_kws_list, set())
+
+    def test_filter_keywords_only_exclude_should_filter_keywords(self):
+        all_kws = set(KEYWORDDOC_WITH_TAGS)
+        tag1_kws = set(kw for kw in KEYWORDDOC_WITH_TAGS if "tag1" in list(kw.tags))
+        tag2_kws = set(kw for kw in KEYWORDDOC_WITH_TAGS if "tag2" in list(kw.tags))
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="", exclude="tag1"
+        )
+        self.assertCountEqual(filtered_kws_list, all_kws - tag1_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="", exclude="tag2"
+        )
+        self.assertCountEqual(filtered_kws_list, all_kws - tag2_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="", exclude="tag1ORnot_at_tag"
+        )
+        self.assertCountEqual(filtered_kws_list, all_kws - tag1_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="", exclude="tag1ORtag2"
+        )
+        self.assertCountEqual(filtered_kws_list, all_kws - (tag1_kws | tag2_kws))
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="", exclude="tag1ANDtag2"
+        )
+        self.assertCountEqual(filtered_kws_list, all_kws - (tag1_kws & tag2_kws))
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="", exclude="not_a_tag"
+        )
+        self.assertCountEqual(filtered_kws_list, all_kws)
+
+    def test_filter_keywords_include_exclude_should_filter_keywords(self):
+        tag1_kws = set(kw for kw in KEYWORDDOC_WITH_TAGS if "tag1" in list(kw.tags))
+        tag2_kws = set(kw for kw in KEYWORDDOC_WITH_TAGS if "tag2" in list(kw.tags))
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="tag1", exclude="tag1"
+        )
+        self.assertCountEqual(filtered_kws_list, tag1_kws - tag1_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="tag1", exclude="tag2"
+        )
+        self.assertCountEqual(filtered_kws_list, tag1_kws - tag2_kws)
+
+        filtered_kws_list = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="tag1ORtag2", exclude="tag1ANDtag2"
+        )
+        self.assertCountEqual(
+            filtered_kws_list, (tag1_kws | tag2_kws) - (tag1_kws & tag2_kws)
+        )
+
+    def test_filter_keywords_should_be_indempotent(self):
+        """
+        Feeding _filter_keywords with its own output (same args) should return the same output.
+        """
+        filtered_kws_list1 = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="", exclude=""
+        )
+        filtered_kws_list2 = KeywordsExtractor._filter_keywords(
+            filtered_kws_list1, include="", exclude=""
+        )
+
+        self.assertEqual(filtered_kws_list1, filtered_kws_list2)
+
+        filtered_kws_list1 = KeywordsExtractor._filter_keywords(
+            KEYWORDDOC_WITH_TAGS, include="tag1", exclude="tag2"
+        )
+        filtered_kws_list2 = KeywordsExtractor._filter_keywords(
+            filtered_kws_list1, include="tag1", exclude="tag2"
+        )
+
+        self.assertEqual(filtered_kws_list1, filtered_kws_list2)

--- a/tests/unit/cli/keywords/keywords_importer.py
+++ b/tests/unit/cli/keywords/keywords_importer.py
@@ -12,7 +12,12 @@ class KeywordsImporterTests(unittest.TestCase):
         self.fixture_path = FIXTURE_PATH
         self.client = Client("http://localhost:8000", "rfhub", "rfhub")
         self.rfhub_importer = KeywordsImporter(
-            self.client, (self.fixture_path,), True, load_mode="insert"
+            self.client,
+            (self.fixture_path,),
+            True,
+            load_mode="insert",
+            include="",
+            exclude="",
         )
 
     def test_import_data(self):
@@ -22,6 +27,8 @@ class KeywordsImporterTests(unittest.TestCase):
                 (self.fixture_path / "LibWithInit",),
                 True,
                 load_mode="insert",
+                include="",
+                exclude="",
             )
             rsps.add(
                 responses.GET,
@@ -60,6 +67,8 @@ class KeywordsImporterTests(unittest.TestCase):
                 (self.fixture_path / "LibWithInit",),
                 True,
                 load_mode="insert",
+                include="",
+                exclude="",
             )
             rsps.add(
                 responses.GET,
@@ -98,6 +107,8 @@ class KeywordsImporterTests(unittest.TestCase):
                 (self.fixture_path / "LibWithInit",),
                 True,
                 load_mode="append",
+                include="",
+                exclude="",
             )
             rsps.add(
                 responses.POST,
@@ -129,6 +140,8 @@ class KeywordsImporterTests(unittest.TestCase):
                 (self.fixture_path / "LibWithInit",),
                 True,
                 load_mode="update",
+                include="",
+                exclude="",
             )
             rsps.add(
                 responses.GET,
@@ -170,6 +183,8 @@ class KeywordsImporterTests(unittest.TestCase):
                 (self.fixture_path / "LibWithInit",),
                 True,
                 load_mode="merge",
+                include="",
+                exclude="",
             )
             rsps.add(
                 responses.GET,

--- a/tests/unit/cli/keywords/test_data.py
+++ b/tests/unit/cli/keywords/test_data.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import robot.libraries
+from robot.libdocpkg.model import KeywordDoc
 
 from rfhub2.cli.keywords.keywords_importer import CollectionUpdateWithKeywords
 from rfhub2.model import Collection, CollectionUpdate, KeywordUpdate, NestedKeyword
@@ -199,3 +200,10 @@ EXPECTED_COLLECTION_WITH_KW_1 = CollectionUpdateWithKeywords(
 EXPECTED_COLLECTION_WITH_KW_2 = CollectionUpdateWithKeywords(
     EXPECTED_COLLECTION_2, EXPECTED_COLLECTION_KEYWORDS_2
 )
+KEYWORDDOC_WITH_TAGS = [
+    KeywordDoc(name="kw1", tags=("tag1")),  # tag1
+    KeywordDoc(name="kw2", tags=("tag1", "tag2")),  # tag1|tag2 and tag1&tag2
+    KeywordDoc(name="kw3", tags=("tag1", "tag3")),  # tag1|tag2
+    KeywordDoc(name="kw4", tags=("tag2", "tag3")),  # tag2
+    KeywordDoc(name="kw5", tags=()),
+]


### PR DESCRIPTION
Hi all!

This PR brings a new feature: filtering keywords by their tags (fixes #361).

`rfhub-cli` now has 2 more options: `--include` and `--exclude`. They behave the same way as the  `--include` and `--exclude` options from RobotFramework (see [robot user manual](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#tag-patterns)).

Few examples:
```bash
# Includes only keywords containing "tag1"
rfhub2-cli --include tag1 .

# Includes keywords with tags "tag1" or "tag2" and exclude keywords with tag "tag3" and "tag4" but not "tag5"
rfhub2-cli --include tag1ORtag2 --exclude tag3ANDtag4NOTtag5 .

# Includes keywords with tags starting with "awesome-tag-"
rfhub2-cli --include awesome-tag-* .

# Tag pattern are underscore and case insensitive:
#   Includes tag "my-tag":
rfhub2-cli --include _?_y-TA____g .
```

I have however a few points I'm not really sure about:

- WDYT of the help sections and readme about this new feature? Are they understandable and clear enought? (I'm not native so please feel free to correct them)
- from now on, if a user includes or excludes a tag, it might find himself with a lot of loaded but empty collections (since all the keywords were filtered). Even thought it's not a big matter, is there anything that can be done about that? 
- should we add the short options "-i" and "-e"? (currently not implemented)

Note also that this feature is not implemented for statistics mode.

Anyway let me now what you think!