### PR TITLE
Add sorting CollectionWithStats by keyword count

### DIFF
--- a/rfhub2/db/migrate.py
+++ b/rfhub2/db/migrate.py
@@ -2,12 +2,12 @@ from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic import command
 from pathlib import Path
+from sqlalchemy import inspect
 from sqlalchemy.engine import Connection, Engine
-from sqlalchemy.engine.reflection import Inspector
 
 
 def has_tables(connection: Connection) -> bool:
-    inspector = Inspector(connection)
+    inspector = inspect(connection)
     tables = inspector.get_table_names()
     return len(tables) > 0
 

--- a/rfhub2/db/repository/suite_repository.py
+++ b/rfhub2/db/repository/suite_repository.py
@@ -1,7 +1,7 @@
 from itertools import zip_longest
 from typing import Dict, List, Optional, Tuple
 
-from sqlalchemy import or_, Column
+from sqlalchemy import or_, Column, select
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql import func
 from sqlalchemy.orm.session import Session
@@ -99,7 +99,7 @@ class SuiteRepository(BaseRepository):
         )
         deleted = (
             self.session.query(Suite)
-            .filter(Suite.id.in_(suite_ids))
+            .filter(Suite.id.in_(select(suite_ids)))
             .delete(synchronize_session=False)
         )
         self.session.commit()

--- a/rfhub2/model/__init__.py
+++ b/rfhub2/model/__init__.py
@@ -69,7 +69,8 @@ class Collection(NestedCollection, CollectionUpdate):
 
 
 class CollectionWithStats(Collection):
-    times_used: Optional[int]
+    times_used: int
+    keyword_count: int
 
 
 class Keyword(NestedKeyword):

--- a/tests/unit/api/endpoints/base_endpoint_tests.py
+++ b/tests/unit/api/endpoints/base_endpoint_tests.py
@@ -147,9 +147,9 @@ class BaseApiEndpointTest(unittest.TestCase):
         "path": "/some/file",
     }
     COLLECTION_UPDATED = {**COLLECTION_3, **COLLECTION_TO_UPDATE}
-    COLLECTION_1_WITH_STATS = {**COLLECTION_1, "times_used": 20}
-    COLLECTION_2_WITH_STATS = {**COLLECTION_2, "times_used": 15}
-    COLLECTION_3_WITH_STATS = {**COLLECTION_3, "times_used": None}
+    COLLECTION_1_WITH_STATS = {**COLLECTION_1, "times_used": 20, "keyword_count": 3}
+    COLLECTION_2_WITH_STATS = {**COLLECTION_2, "times_used": 15, "keyword_count": 1}
+    COLLECTION_3_WITH_STATS = {**COLLECTION_3, "times_used": 0, "keyword_count": 0}
     KEYWORD_1_WITH_STATS = {**KEYWORD_1, "times_used": 10, "avg_elapsed": 100.0}
     KEYWORD_2_WITH_STATS = {**KEYWORD_2, "times_used": 10, "avg_elapsed": 500.0}
     KEYWORD_3_WITH_STATS = {**KEYWORD_3, "times_used": None, "avg_elapsed": None}

--- a/tests/unit/api/endpoints/collections_tests.py
+++ b/tests/unit/api/endpoints/collections_tests.py
@@ -93,6 +93,22 @@ class CollectionsApiTest(BaseApiEndpointTest):
             ],
         )
 
+    def test_get_all_collections_with_statistics_ordered_by_calculated_fields(self):
+        for order in ["keyword_count", "times_used"]:
+            with self.subTest(order=order):
+                response = self.client.get(f"api/v1/collections/stats?order={order}")
+                self.assertEqual(response.status_code, 200)
+                body = response.json()
+                self.assertEqual(len(body), 3)
+                self.assertEqual(
+                    body,
+                    [
+                        self.COLLECTION_3_WITH_STATS,
+                        self.COLLECTION_2_WITH_STATS,
+                        self.COLLECTION_1_WITH_STATS,
+                    ],
+                )
+
     def test_create_new_collection(self):
         response = self.auth_client.post(
             "api/v1/collections/", json=self.COLLECTION_TO_CREATE


### PR DESCRIPTION
Based on PR #450 with a goal to simplify the changes.
First commit adds calculated column `keyword_count` to CollectionWithStats model and enabled ordering by this column. It also enables it for existing calculated column `times_used`. Both calculated fields are updated to non-optional returning 0 when no keywords or usage found.
Second commit adds fixes for SqlAlchemy deprecation warnings present since version 1.4.

Version is not updated on purpose to release it once UI changes are ready.